### PR TITLE
Select distinct parsing tables to delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Allow for none value in resource schema [#93](https://github.com/etalab/udata-hydra/pull/93)
 - Handle other file formats [#92](https://github.com/etalab/udata-hydra/pull/92)
 - Add a quiet option on load catalog [#95](https://github.com/datagouv/hydra/pull/95)
+- Select distinct parsing tables to delete [#96](https://github.com/datagouv/hydra/pull/96)
 
 ## 1.0.1 (2023-01-04)
 

--- a/udata_hydra/cli.py
+++ b/udata_hydra/cli.py
@@ -270,7 +270,7 @@ async def purge_csv_tables():
     # Fetch all parsing tables from checks where we don't have any entry on
     # md5(url) in catalog or all entries are marked as deleted.
     q = """
-    SELECT checks.parsing_table
+    SELECT DISTINCT checks.parsing_table
     FROM checks
     LEFT JOIN (
         select url, MAX(id) as id, BOOL_AND(deleted) as deleted


### PR DESCRIPTION
Prevent having duplicate parsing_tables being returned, making way fewer iteration for the job.
It reduces the number of rows returned from 75K to 12K on dev env for example.

Indeed, we then use the table name to delete it and update all checks that could have a reference to it as NULL.
We don't need to keep duplicate entry for each check.