### PR TITLE
fix: fix wrong types returns

### DIFF
--- a/udata_hydra/analysis/helpers.py
+++ b/udata_hydra/analysis/helpers.py
@@ -11,7 +11,7 @@ def to_json(value: str) -> str:
     return value
 
 
-def _parse_dt(value: str) -> datetime:
+def _parse_dt(value: str) -> Union[datetime, None]:
     """For performance reasons, we try first with dateutil and fallback on dateparser"""
     try:
         return dateutil_parser(value)
@@ -24,5 +24,5 @@ def to_date(value: str) -> Union[date, None]:
     return parsed.date() if parsed else None
 
 
-def to_datetime(value: str) -> datetime:
+def to_datetime(value: str) -> Union[datetime, None]:
     return _parse_dt(value)


### PR DESCRIPTION
Small fix regarding wrong types returns.

_Note:
In order to comply with the Python 3.9 retro-compatibility, we use only Python 3.9-compatible typings for now. The switch to cleaner >=3.10 typings are all gathered in the following draft PR once we switched to Python 3.11: https://github.com/datagouv/hydra/pull/108_