### PR TITLE
tests: add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Add tests coverage feature [#122](https://github.com/datagouv/hydra/pull/122)
 - Refactor routes [#117](https://github.com/datagouv/hydra/pull/117)
 - Fix Ruff configuration [#117](https://github.com/datagouv/hydra/pull/117)
+- Add some API tests to improve coverage [#123](https://github.com/datagouv/hydra/pull/123)
 
 ## 1.0.1 (2023-01-04)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import asyncio
 import hashlib
 import os
+import uuid
 from datetime import datetime
 
 import asyncpg
@@ -166,6 +167,11 @@ async def insert_fake_resource():
 
 
 @pytest_asyncio.fixture
+def fake_resource_id():
+    return uuid.uuid4
+
+
+@pytest_asyncio.fixture
 async def fake_check():
     async def _fake_check(
         status=200,
@@ -175,7 +181,7 @@ async def fake_check():
         created_at=None,
         headers={"x-do": "you"},
         checksum=None,
-        resource_id="c4e3a9fb-4415-488e-ba57-d05269b27adf",
+        resource_id=RESOURCE_ID,
         detected_last_modified_at=None,
         parsing_table=False,
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,8 @@ import nest_asyncio
 import pytest
 from minicli import run
 
+from tests.conftest import RESOURCE_ID
+
 pytestmark = pytest.mark.asyncio
 nest_asyncio.apply()
 
@@ -121,7 +123,7 @@ async def test_load_catalog_url_has_changed(setup_catalog, rmock, db, catalog_co
 
     # check that we still only have one entry for this resource in the catalog
     res = await db.fetch(
-        "SELECT * FROM catalog WHERE resource_id = $1", "c4e3a9fb-4415-488e-ba57-d05269b27adf"
+        f"SELECT * FROM catalog WHERE resource_id = $1", f"{RESOURCE_ID}"
     )
     assert len(res) == 1
     assert res[0]["url"] == "https://example.com/resource-0"


### PR DESCRIPTION
Since we added tests coverage (https://github.com/datagouv/hydra/pull/122), I saw that some API lines were not covered by tests.

This PR add some tests coverage, and slightly refactor API tests.