### PR TITLE
clean: change API_TOKEN to API_KEY naming, better default API token content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 - Fix Ruff configuration [#117](https://github.com/datagouv/hydra/pull/117)
 - Add some API tests to improve coverage [#123](https://github.com/datagouv/hydra/pull/123)
 - Fix health check endpoint route which was wrongly removed, and add test for API health check endpoint to make sure this endpoint is working as expected [#128](https://github.com/datagouv/hydra/pull/128)
-- Add basic authentication via admin token using a new auth logic for all POST/PUT/DELETE endpoints [#130](https://github.com/datagouv/hydra/pull/130)
+- Add basic authentication via API key using a bearer token auth for all POST/PUT/DELETE endpoints [#130](https://github.com/datagouv/hydra/pull/130)
 
 ## 1.0.1 (2023-01-04)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ def is_harvested(request):
 
 @pytest.fixture
 def api_headers() -> dict:
-    return {"Authorization": f"Bearer {config.API_TOKEN}"}
+    return {"Authorization": f"Bearer {config.API_KEY}"}
 
 
 @pytest.fixture

--- a/udata_hydra/config_default.toml
+++ b/udata_hydra/config_default.toml
@@ -12,7 +12,7 @@ TESTING = false
 MAX_POOL_SIZE = 50
 USER_AGENT = "udata-hydra/1.0"
 
-API_TOKEN = "udata_hydra_api_token_to_change"
+API_KEY = "hydra_api_key_to_change"
 
 # -- crawler settings -- #
 

--- a/udata_hydra/utils/auth.py
+++ b/udata_hydra/utils/auth.py
@@ -62,8 +62,8 @@ def token_auth_middleware(
                 reason="Invalid token scheme",
             )
 
-        if token == config.API_TOKEN:
-            request[request_property] = {"username": "admin"}
+        if token == config.API_KEY:
+            request[request_property] = {"username": "udata"}
         else:
             raise web.HTTPForbidden(reason="Invalid authentication token")
 


### PR DESCRIPTION
- change API_TOKEN to API_KEY naming (https://www.gomomento.com/blog/api-keys-vs-tokens-whats-the-difference/)
- better default API token content