### PR TITLE
clean: remove unused imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The architecture for the full workflow is the following:
 ![Full workflow architecture](docs/archi-idd-IDD.drawio.png)
 
 
-The hydra crawler is one of the components of the architecture. It will check if resource is available, analyze the type of file if the resource has been modified, and analyze the CSV content. It will also convert CSV resources to database tables and send the data to a udata instance.
+The hydra crawler is one of the components of the architecture. It will check if resource is available, analyse the type of file if the resource has been modified, and analyse the CSV content. It will also convert CSV resources to database tables and send the data to a udata instance.
 
 ![Crawler architecture](docs/hydra.drawio.png)
 
@@ -302,7 +302,7 @@ UDATA_URI_API_KEY = "example.api.key"
 SENTRY_DSN = "https://{my-sentry-dsn}"
 ```
 
-The webhook integration sends HTTP messages to `udata` when resources are analyzed or checked to fill resources extras.
+The webhook integration sends HTTP messages to `udata` when resources are analysed or checked to fill resources extras.
 
 Regarding analysis, there is a phase called "change detection". It will try to guess if a resource has been modified based on different criterions:
 - harvest modified date in catalog

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,7 +14,6 @@ from aiohttp.client_exceptions import ClientError, ClientResponseError
 from yarl import URL
 
 from tests.conftest import DATASET_ID, RESOURCE_ID
-from udata_hydra.crawl import RESOURCE_RESPONSE_STATUSES
 from udata_hydra.db.resource import Resource
 
 pytestmark = pytest.mark.asyncio

--- a/udata_hydra/routes/checks.py
+++ b/udata_hydra/routes/checks.py
@@ -6,7 +6,7 @@ from aiohttp import web
 from marshmallow import ValidationError
 
 from udata_hydra import config, context
-from udata_hydra.crawl import RESOURCE_RESPONSE_STATUSES, check_url
+from udata_hydra.crawl import check_url
 from udata_hydra.db.check import Check
 from udata_hydra.db.resource import Resource
 from udata_hydra.schemas import CheckSchema


### PR DESCRIPTION
Minor cleaning PR.

- Remove unused imports
- Standardize spelling of "analysing" throughout code and docs