### PR TITLE
Add trailing slash on status route for coherence with others

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -240,7 +240,7 @@ async def test_api_get_resource_status(
 ):
     await insert_fake_resource(db, status=resource_status)
     # await fake_check()
-    resp = await client.get(f"/api/resources/{RESOURCE_ID}/status")
+    resp = await client.get(f"/api/resources/{RESOURCE_ID}/status/")
     assert resp.status == 200
     data = await resp.json()
     assert data["resource_id"] == RESOURCE_ID

--- a/udata_hydra/routes/__init__.py
+++ b/udata_hydra/routes/__init__.py
@@ -18,7 +18,7 @@ routes: list = [
     web.post("/api/checks/", create_check),
     # Routes for resources
     web.get("/api/resources/", get_resource),
-    web.get("/api/resources/{resource_id}/status", get_resource_status),
+    web.get("/api/resources/{resource_id}/status/", get_resource_status),
     web.post("/api/resources/", create_resource),
     web.put("/api/resources/", update_resource),
     web.delete("/api/resources/", delete_resource),


### PR DESCRIPTION
Follows https://github.com/datagouv/hydra/pull/119

We would actually like to have a redirection instead of a 404 on trailing slash or not, but for now let's keep it coherent with other routes at least.