### PR TITLE
refactor: delete resource as a CRUD method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - Use Python 3.11 instead of 3.9 for performance improvements and future compatibility [#101](https://github.com/datagouv/hydra/pull/101)
 - Refactor and split code from `crawl.py` into separate files using refactored `db.Resource` class methods and static methods [#135](https://github.com/datagouv/hydra/pull/135)
 - Allow routes with or without trailing slashes [#158](https://github.com/datagouv/hydra/pull/158)
+- Delete resource as a CRUD method [#161](https://github.com/datagouv/hydra/pull/161)
 
 ## 1.0.1 (2023-01-04)
 

--- a/udata_hydra/db/resource.py
+++ b/udata_hydra/db/resource.py
@@ -99,6 +99,17 @@ class Resource:
                             priority = $5;"""
             await connection.execute(q, dataset_id, resource_id, url, status, priority)
 
+    @classmethod
+    async def delete(
+        cls,
+        resource_id: str,
+    ) -> None:
+        pool = await context.pool()
+        async with pool.acquire() as connection:
+            # Mark resource as deleted in catalog table
+            q = f"""UPDATE catalog SET deleted = TRUE WHERE resource_id = '{resource_id}';"""
+            await connection.execute(q)
+
     @staticmethod
     def get_excluded_clause() -> str:
         """Return the WHERE clause to get only resources from the check which:

--- a/udata_hydra/routes/resources.py
+++ b/udata_hydra/routes/resources.py
@@ -114,10 +114,7 @@ async def delete_resource(request: web.Request) -> web.Response:
 
     resource_id: str = valid_payload["resource_id"]
 
-    pool = request.app["pool"]
-    async with pool.acquire() as connection:
-        # Mark resource as deleted in catalog table
-        q = f"""UPDATE catalog SET deleted = TRUE WHERE resource_id = '{resource_id}';"""
-        await connection.execute(q)
+    # Mark resource as deleted in catalog table
+    await Resource.delete(resource_id)
 
     return web.json_response({"message": "deleted"})


### PR DESCRIPTION
Delete resource as a CRUD method.
More standard and useful for the upcoming https://github.com/datagouv/hydra/pull/132 PR (fully RESTful endpoints).