### PR TITLE
refactor: refactor function to get no_backoff domains and add PostgreSQL indexes to improve DB queries perfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Refactor function to get no_backoff domains and add PostgreSQL indexes to improve DB queries perfs [#171](https://github.com/datagouv/hydra/pull/171)
 
 ## 2.0.0 (2024-09-24)
 

--- a/udata_hydra/migrations/main/20240926_add_indexes.sql
+++ b/udata_hydra/migrations/main/20240926_add_indexes.sql
@@ -1,0 +1,6 @@
+-- add indexes on checks table, to improve performance when querying depending on resource_id and/or created_at
+CREATE INDEX IF NOT EXISTS resource_id_idx ON checks (resource_id);
+CREATE INDEX IF NOT EXISTS created_at_idx ON checks (created_at);
+
+-- add index on catalog table, to improve performance when querying depending on last_check
+CREATE INDEX IF NOT EXISTS last_check_idx ON catalog (last_check);


### PR DESCRIPTION
This PR aims to drastically improve DB queries performance in two ways:
- Refactor function to get no_backoff domains, in order to avoid unnecessary queries
- Add PostgreSQL indexes to improve performance when querying:
    - add indexes on `checks` table for `resource_id` and `created_at` columns
    - add index on `catalog` table for `last_check` column