### PR TITLE
fix: fix resources exceptions routes responses, add tests, update README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Refactor function to get no_backoff domains and add PostgreSQL indexes to improve DB queries perfs [#171](https://github.com/datagouv/hydra/pull/171)
 - Clean changelog and remove useless section in pyproject.toml [#175](https://github.com/datagouv/hydra/pull/175)
 - Refactor purge_checks CLI to use a date limit instead of a number [#174](https://github.com/datagouv/hydra/pull/174)
+- Fix resources exceptions routes responses, add resources exceptions tests [#176](https://github.com/datagouv/hydra/pull/176)
 
 ## 2.0.0 (2024-09-24)
 

--- a/README.md
+++ b/README.md
@@ -397,6 +397,13 @@ Refer to each section to learn how to launch them. The only differences from dev
 - use `HYDRA_SETTINGS` env var to point to your custom `config.toml`
 - use `HYDRA_APP_SOCKET_PATH` to configure where aiohttp should listen to a [reverse proxy connection (eg nginx)](https://docs.aiohttp.org/en/stable/deployment.html#nginx-configuration) and use `udata-hydra-app` to launch the app server
 
+## Adding large resources exceptions
+
+Here is an example of how to add a large resource exception to Hydra's database through the API:
+```bash
+curl -X POST https://dev-crawler.data.gouv.fr/api/resources-exceptions  -H "Authorization: Bearer abcdefghijklmopqrstuvw1234567890" -d "{'resource_id': 'f868cca6-8da1-4369-a78d-47463f19a9a3', 'table_indexes': {'SIRET': "index", "immatriculation": "index"}}"
+```
+
 ## Contributing
 
 Before contributing to the repository and making any PR, it is necessary to initialize the pre-commit hooks:

--- a/README.md
+++ b/README.md
@@ -119,20 +119,26 @@ The API serves the following endpoints:
 - `GET` on `/api/checks/aggregate?group_by={column}&created_at={date}` to get checks occurences grouped by a `column` for a specific `date`
 
 *Related to resources:*
-- `GET` on `/api/resources?resource_id={resource_id}` to get a resource in the DB "catalog" table from its `resource_id`
+- `GET` on `/api/resource/{resource_id}` to get a resource in the DB "catalog" table from its `resource_id`
 - `POST` on `/api/resources` to receive a resource creation event from a source. It will create a new resource in the DB "catalog" table and mark it as priority for next crawling
-- `PUT` on `/api/resources` to update a resource in the DB "catalog" table
-- `DELETE` on `/api/resources` to delete a resource in the DB "catalog" table
+- `PUT` on `/api/resources/{resource_id}` to update a resource in the DB "catalog" table
+- `DELETE` on `/api/resources/{resource_id}` to delete a resource in the DB "catalog" table
 
 > :warning: **Warning: the following routes are deprecated and need be removed in the future:**
 > - `POST` on `/api/resource/created` -> use `POST` on `/api/resources/` instead
 > - `POST` on `/api/resource/updated` -> use `PUT` on `/api/resources/` instead
 > - `POST` on `/api/resource/deleted` -> use `DELET`E on `/api/resources/` instead
 
+*Related to resources exceptions:*
+- `GET` on `/api/resources-exceptions` to get the list all resources exceptions
+- `POST` on `/api/resources-exceptions` to create a new resource exception in the DB
+- `DELETE` on `/api/resources-exceptions/{resource_id}` to delete a resource exception from the DB
+
 *Related to some status and health check:*
 - `GET` on `/api/status/crawler` to get the crawling status
 - `GET` on `/api/status/worker` to get the worker status
 - `GET` on `/api/stats` to get the crawling stats
+- `GET` on `/api/health` to get the API version number and environment
 
 More details about some enpoints are provided below with examples, but not for all of them:
 
@@ -213,7 +219,7 @@ $ curl -s "http://localhost:8000/api/checks/all?url=http://www.drees.sante.gouv.
 ]
 ```
 
-#### get checks occurences grouped by a column for a specific date
+#### Get checks occurences grouped by a column for a specific date
 
 Works with `?group_by={column}` and `?created_at={date}`.
 `date` should be a date in format `YYYY-MM-DD` or the default keyword `today`.
@@ -254,6 +260,28 @@ $ curl -s "http://localhost:8000/api/checks/aggregate?group_by=domain&created_at
     "count": 1
   }
 ]
+```
+
+#### Adding a resource exception
+
+```bash
+$ curl  -X POST http://localhost:8000/api/resources-exceptions
+        -H "Authorization: Bearer <myAPIkey>"
+        -d "{'resource_id': 'f868cca6-8da1-4369-a78d-47463f19a9a3', 'table_indexes': {'SIRET': "index", "immatriculation": "index"}}"
+```
+
+...or, if you don't want to add table indexes:
+```bash
+$ curl  -X POST http://localhost:8000/api/resources-exceptions
+        -H "Authorization: Bearer <myAPIkey>"
+        -d "{'resource_id': 'f868cca6-8da1-4369-a78d-47463f19a9a3'}"
+```
+
+#### Deleting a resource exception
+
+```bash
+$ curl  -X DELETE http://localhost:8000/api/resources-exceptions/f868cca6-8da1-4369-a78d-47463f19a9a3
+        -H "Authorization: Bearer <myAPIkey>"
 ```
 
 #### Get crawling status
@@ -396,13 +424,6 @@ For example, to set the log level to `DEBUG` when initializing the database, use
 Refer to each section to learn how to launch them. The only differences from dev to prod are:
 - use `HYDRA_SETTINGS` env var to point to your custom `config.toml`
 - use `HYDRA_APP_SOCKET_PATH` to configure where aiohttp should listen to a [reverse proxy connection (eg nginx)](https://docs.aiohttp.org/en/stable/deployment.html#nginx-configuration) and use `udata-hydra-app` to launch the app server
-
-## Adding large resources exceptions
-
-Here is an example of how to add a large resource exception to Hydra's database through the API:
-```bash
-curl -X POST https://dev-crawler.data.gouv.fr/api/resources-exceptions  -H "Authorization: Bearer abcdefghijklmopqrstuvw1234567890" -d "{'resource_id': 'f868cca6-8da1-4369-a78d-47463f19a9a3', 'table_indexes': {'SIRET': "index", "immatriculation": "index"}}"
-```
 
 ## Contributing
 

--- a/tests/test_api/test_api_resources_exceptions.py
+++ b/tests/test_api/test_api_resources_exceptions.py
@@ -1,0 +1,96 @@
+"""
+NB: we can't use pytest-aiohttp helpers because
+it will interfere with the rest of our async code
+"""
+
+import pytest
+
+from tests.conftest import (
+    NOT_EXISTING_RESOURCE_ID,
+    RESOURCE_EXCEPTION_ID,
+    RESOURCE_EXCEPTION_TABLE_INDEXES,
+    RESOURCE_ID,
+)
+from udata_hydra.db.resource import Resource
+from udata_hydra.utils import is_valid_uri
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_get_resources_exceptions(setup_catalog_with_resource_exception, client):
+    resp = await client.get(path="/api/resources-exceptions")
+    assert resp.status == 200
+    data: dict = await resp.json()
+    assert len(data) == 1
+    assert data[0]["resource_id"] == RESOURCE_EXCEPTION_ID
+
+
+async def test_create_resource_exception(
+    setup_catalog, client, api_headers, api_headers_wrong_token
+):
+    # Test API call with no token
+    resp = await client.post(
+        path="/api/resources-exceptions",
+        headers=None,
+        json={
+            "resource_id": RESOURCE_ID,
+            "table_indexes": RESOURCE_EXCEPTION_TABLE_INDEXES,
+        },
+    )
+    assert resp.status == 401
+
+    # Test API call with invalid token
+    resp = await client.post(
+        path="/api/resources-exceptions",
+        headers=api_headers_wrong_token,
+        json={
+            "resource_id": RESOURCE_ID,
+            "table_indexes": RESOURCE_EXCEPTION_TABLE_INDEXES,
+        },
+    )
+    assert resp.status == 403
+
+    # Test API call with invalid POST data
+    stupid_post_data: dict = {"stupid": "stupid"}
+    resp = await client.post(
+        path="/api/resources-exceptions", headers=api_headers, json=stupid_post_data
+    )
+    assert resp.status == 400
+
+    # Test API call success
+    resp = await client.post(
+        path="/api/resources-exceptions",
+        headers=api_headers,
+        json={
+            "resource_id": RESOURCE_ID,
+            "table_indexes": RESOURCE_EXCEPTION_TABLE_INDEXES,
+        },
+    )
+    assert resp.status == 201
+    data: dict = await resp.json()
+    assert data["resource_id"] == RESOURCE_ID
+
+
+async def test_delete_resource_exception(
+    setup_catalog_with_resource_exception, client, api_headers, api_headers_wrong_token
+):
+    # Test API call with wrong token
+    resp = await client.delete(
+        path=f"/api/resources-exceptions/{RESOURCE_EXCEPTION_ID}",
+        headers=api_headers_wrong_token,
+    )
+    assert resp.status == 403
+
+    # Test API call with non existing resource id data
+    resp = await client.delete(
+        path=f"/api/resources-exceptions/{NOT_EXISTING_RESOURCE_ID}",
+        headers=api_headers,
+    )
+    assert resp.status == 404
+
+    # Test API call success
+    resp = await client.delete(
+        path=f"/api/resources-exceptions/{RESOURCE_EXCEPTION_ID}",
+        headers=api_headers,
+    )
+    assert resp.status == 204

--- a/udata_hydra/app.py
+++ b/udata_hydra/app.py
@@ -15,13 +15,7 @@ async def app_factory() -> web.Application:
         if "pool" in app:
             await app["pool"].close()
 
-    app = web.Application(
-        middlewares=[
-            token_auth_middleware(
-                exclude_methods=("GET",), exclude_routes=("/api/resources-exceptions",)
-            )
-        ]
-    )
+    app = web.Application(middlewares=[token_auth_middleware(exclude_methods=("GET",))])
     app.add_routes(routes)
     app.on_startup.append(app_startup)
     app.on_cleanup.append(app_cleanup)

--- a/udata_hydra/routes/checks.py
+++ b/udata_hydra/routes/checks.py
@@ -67,7 +67,7 @@ async def create_check(request: web.Request) -> web.Response:
     except ValidationError as err:
         raise web.HTTPBadRequest(text=json.dumps(err.messages))
     except KeyError as e:
-        raise web.HTTPBadRequest(text=f"Missing key: {e}")
+        raise web.HTTPBadRequest(text=f"Missing key: {str(e)}")
 
     # Get URL from resource_id
     try:

--- a/udata_hydra/routes/resources_exceptions.py
+++ b/udata_hydra/routes/resources_exceptions.py
@@ -3,11 +3,11 @@ import uuid
 
 from aiohttp import web
 from asyncpg import Record
+from asyncpg.exceptions import UniqueViolationError
 
 from udata_hydra.db.resource import Resource
 from udata_hydra.db.resource_exception import ResourceException
 from udata_hydra.schemas import ResourceExceptionSchema
-from udata_hydra.utils import get_request_params
 
 
 async def get_all_resources_exceptions(request: web.Request) -> web.Response:
@@ -25,12 +25,11 @@ async def create_resource_exception(request: web.Request) -> web.Response:
     """Endpoint to receive a resource exception creation event from a source
     Will create a new exception in the DB "resources_exceptions" table.
     Respond with a 201 status code with the created resource exception
-    If error, respond with a 400 status code
     """
     try:
         payload = await request.json()
         resource_id: str = payload["resource_id"]
-        table_indexes: dict[str, str] = payload["table_indexes"]
+        table_indexes: dict[str, str] | None = payload.get("table_indexes", None)
         # format should be like this:
         #    {
         #       "column_name": "index_type",
@@ -46,7 +45,9 @@ async def create_resource_exception(request: web.Request) -> web.Response:
             table_indexes=table_indexes,
         )
     except ValueError as err:
-        raise web.HTTPBadRequest(text=f"Resource exception could not be created: {err}")
+        raise web.HTTPBadRequest(text=f"Resource exception could not be created: {str(err)}")
+    except UniqueViolationError:
+        raise web.HTTPBadRequest(text="Resource exception already exists")
 
     return web.json_response(ResourceExceptionSchema().dump(dict(resource_exception)), status=201)
 
@@ -54,12 +55,11 @@ async def create_resource_exception(request: web.Request) -> web.Response:
 async def delete_resource_exception(request: web.Request) -> web.Response:
     """Endpoint to delete a resource exception from the DB
     Respond with a 204 status code
-    If error, respond with a 400 status code
     """
     try:
         resource_id = str(uuid.UUID(request.match_info["resource_exception_id"]))
     except Exception as e:
-        raise web.HTTPBadRequest(text=json.dumps({"error": str(e)}))
+        raise web.HTTPBadRequest(text=f"error: {str(e)}")
 
     resource: Record | None = await Resource.get(resource_id)
     if not resource:

--- a/udata_hydra/schemas/__init__.py
+++ b/udata_hydra/schemas/__init__.py
@@ -1,3 +1,4 @@
 # ruff: noqa: F401
 from .check import CheckGroupBy, CheckSchema
 from .resource import ResourceDocumentSchema, ResourceSchema
+from .resource_exception import ResourceExceptionSchema

--- a/udata_hydra/schemas/resource_exception.py
+++ b/udata_hydra/schemas/resource_exception.py
@@ -1,0 +1,7 @@
+from marshmallow import Schema, fields
+
+
+class ResourceExceptionSchema(Schema):
+    id = fields.Str(required=True)
+    resource_id = fields.Str(required=True)
+    table_indexes = fields.Str(allow_none=True)


### PR DESCRIPTION
Fix several serious issues with resources exceptions routes:

- Fix serialisation of resource exception in API responses
- Added a proper Marshmallow schema for resource exception, so that it can be used for serialisation
- Allow posting of a new resources exception with no `tables_indexes`
- Added end-to-end API tests for all resources exceptions routes cases
- Remove resources exception routes to be excluded from auth, so that POST and DELETE are also authenticated routes
- Added documentation on how to make a curl request to the API to add a ressource exception