### PR TITLE
feat: save git commit hash in CI and use it for health check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,9 @@ jobs:
           command: |
             poetry config virtualenvs.in-project true
             poetry install
+      - run:
+          name: Save commit hash in a file
+          command: echo $CIRCLE_SHA1 > .git-commit
       - save_cache:
           key: << pipeline.parameters.cache-prefix >>-{{ arch }}-{{ checksum "poetry.lock" }}
           paths:

--- a/udata_hydra/__init__.py
+++ b/udata_hydra/__init__.py
@@ -31,6 +31,13 @@ class Configurator:
         self.configuration = configuration
         self.check()
 
+        # Read commit hash from .git-commit file
+        try:
+            with open(Path.cwd() / ".git-commit", "r") as f:
+                self.configuration["GIT_COMMIT"] = f.read().strip()
+        except FileNotFoundError:
+            log.warning("No .git-commit file")
+
         # add project metadata to config
         self.configuration["APP_NAME"] = "udata-hydra"
         self.configuration["APP_VERSION"] = importlib.metadata.version("udata-hydra")

--- a/udata_hydra/routes/status.py
+++ b/udata_hydra/routes/status.py
@@ -123,5 +123,9 @@ async def get_health(request: web.Request) -> web.Response:
     test_connection = await request.app["pool"].fetchrow("SELECT 1")
     assert next(test_connection.values()) == 1
     return web.json_response(
-        {"version": config.APP_VERSION, "environment": config.ENVIRONMENT or "unknown"}
+        {
+            "version": config.APP_VERSION,
+            "commit": config.GIT_COMMIT or "unknown",
+            "environment": config.ENVIRONMENT or "unknown",
+        }
     )


### PR DESCRIPTION
Save git commit hash in CI and use it for config and health check, in order to be able to check quickly which version is deployed without having to deal with comparing the dev versions, as an attempt to improving overall developer experience.

Note: not 100% sure the file is imported in the build :)