### PR TITLE
tests: coverage fails if coverage falls under 88%

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "catalog_harvested: use catalog_harvested.csv as source",
 ]
-addopts = "--cov=udata_hydra/ --cov-report term-missing"
+addopts = "--cov=udata_hydra/ --cov-report term-missing --cov-fail-under=88"
 
 [tool.ruff]
 lint = { extend-select = ["I"], ignore = ["F401"] } # ["I"] is to also sort imports with an isort rule # TODO: remove ignore F401 later


### PR DESCRIPTION
Coverage fails if coverage falls under 88%, which is the current tests coverage.

Not exactly sure if this would make the CI tests fail, but it's a good security feature for next development as it will at least show clearly in the CLI if coverage has lowered since that commit.