### PR TITLE
feat: add a quiet option for purge_check and purge_csv_table CLIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix resources exceptions routes responses, add resources exceptions tests [#176](https://github.com/datagouv/hydra/pull/176)
 - Fix CSV analysis CLI [#181](https://github.com/datagouv/hydra/pull/181)
 - Add a `PUT` `/api/resources-exceptions/{id}` route to update a resource exception [#178](https://github.com/datagouv/hydra/pull/178)
+- Add a `quiet` argument for `purge_check` and `purge_csv_table` CLIs [#184](https://github.com/datagouv/hydra/pull/184)
 
 ## 2.0.0 (2024-09-24)
 

--- a/udata_hydra/cli.py
+++ b/udata_hydra/cli.py
@@ -254,8 +254,11 @@ async def migrate(skip_errors: bool = False, dbs: list[str] = ["main", "csv"]):
 
 
 @cli
-async def purge_checks(retention_days: int = 60) -> None:
+async def purge_checks(retention_days: int = 60, quiet: bool = False) -> None:
     """Delete outdated checks that are more than `retention_days` days old"""
+    if quiet:
+        log.setLevel(logging.ERROR)
+
     conn = await connection()
     log.debug(f"Deleting checks that are more than {retention_days} days old...")
     res: Record = await conn.fetchrow(
@@ -266,13 +269,16 @@ async def purge_checks(retention_days: int = 60) -> None:
 
 
 @cli
-async def purge_csv_tables():
+async def purge_csv_tables(quiet: bool = False):
     """Delete converted CSV tables for resources url no longer in catalog"""
     # TODO: check if we should use parsing_table from table_index?
     # And are they necessarily in sync?
 
     # Fetch all parsing tables from checks where we don't have any entry on
     # md5(url) in catalog or all entries are marked as deleted.
+    if quiet:
+        log.setLevel(logging.ERROR)
+
     q = """
     SELECT DISTINCT checks.parsing_table
     FROM checks


### PR DESCRIPTION
Similar to https://github.com/datagouv/data.gouv.fr/issues/1354 which was closed by https://github.com/datagouv/hydra/pull/95:

Add a `quiet` arg for `purge_check` and `purge_csv_table` CLIs, which makes the setting log level on `ERROR`, so that the CLI doesn't output logs by default and thus the infra doesn't send an email on each run of the CLI, unless there is an error.
