### PR TITLE
ci: trigger GitLab deployment pipeline when pushing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,8 @@ jobs:
           name: Configure the SSH deploy private key
           command: |
             mkdir -p ~/.ssh
-            echo "$DEPLOY_PRIVATE_KEY" > ~/.ssh/id_ed25519
+            # CircleCI doesn't accept multiple lines in a single environment variable, so the multiline private key must be base64 encoded, and then decoded here
+            echo "$DEPLOY_PRIVATE_KEY" | base64 -d > ~/.ssh/id_ed25519
             chmod 600 ~/.ssh/id_ed25519
             ssh-keyscan -t rsa gitlab.com >> ~/.ssh/known_hosts
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,17 +107,11 @@ jobs:
             echo "Commit hash: ${CIRCLE_SHA1:0:7}"
             echo "Tag: $CIRCLE_TAG"
       - run:
-          name: Build a distributable package
+          name: Build a distributable package with Poetry
           command: |
             RELEASE_VERSION=$(cat version.txt)
-            if [[ $CIRCLE_TAG ]]; then
-                # This is a tagged release, version has been handled upstream
-                poetry build
-            else
-                # Relies on a dev version like "1.2.1.dev" by default
-                poetry version $RELEASE_VERSION
-                poetry build
-            fi
+            poetry version $RELEASE_VERSION
+            poetry build
       - store_artifacts:
           path: dist
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,12 @@ jobs:
           command: |
             RELEASE_VERSION=$(cat version.txt)
             cd scaffold
+            # Run the script that triggers the Gitlab CI/CD pipeline.
+            # The script args are, in order:
+            # - hydra: the name of the project to deploy (APP_NAME)
+            # - $RELEASE_VERSION: the version to deploy (RELEASE_VERSION)
+            # - env: the environment to deploy to (ENV)
+            # - "": the deploy variables (VARS)
             ./scripts/gitlab-ci-pipeline.sh hydra $RELEASE_VERSION dev ""
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,7 @@ jobs:
           name: Configure the SSH deploy private key
           command: |
             mkdir -p ~/.ssh
+            # DEPLOY_PRIVATE_KEY is the private key related to the "simple-scaffold" GitLab repository, so that it can be cloned
             # CircleCI doesn't accept multiple lines in a single environment variable, so the multiline private key must be base64 encoded, and then decoded here
             echo "$DEPLOY_PRIVATE_KEY" | base64 -d > ~/.ssh/id_ed25519
             chmod 600 ~/.ssh/id_ed25519
@@ -152,6 +153,9 @@ jobs:
             git clone --quiet --depth 1 $SCAFFOLD_REPO_SSH_URL scaffold
       - run:
           name: Trigger Gitlab CI/CD pipeline for Hydra to deploy to dev environment
+          environment:
+            # GITLAB_API_TOKEN is the token related to the "infra" GitLab repository, so that the Gitlab CI/CD pipeline can be triggered
+            GITLAB_API_TOKEN: ${GITLAB_API_TOKEN}
           command: |
             RELEASE_VERSION=$(cat version.txt)
             cd scaffold

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,12 +134,12 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Configure the SSH deploy private key
+          name: Configure the SSH simple-scaffold repository private key
           command: |
             mkdir -p ~/.ssh
-            # DEPLOY_PRIVATE_KEY is the private key related to the "simple-scaffold" GitLab repository, so that it can be cloned
+            # SCAFFOLD_PRIVATE_KEY is the private key related to the "simple-scaffold" GitLab repository, so that it can be cloned
             # CircleCI doesn't accept multiple lines in a single environment variable, so the multiline private key must be base64 encoded, and then decoded here
-            echo "$DEPLOY_PRIVATE_KEY" | base64 -d > ~/.ssh/id_ed25519
+            echo "$SCAFFOLD_PRIVATE_KEY" | base64 -d > ~/.ssh/id_ed25519
             chmod 600 ~/.ssh/id_ed25519
             ssh-keyscan -t rsa gitlab.com >> ~/.ssh/known_hosts
       - run:
@@ -148,7 +148,7 @@ jobs:
             git config --global user.email "root@data.gouv.fr"
             git config --global user.name "datagouv"
       - run:
-          name: Clone scaffold repository
+          name: Clone simple-scaffold repository
           command: |
             git clone --quiet --depth 1 $SCAFFOLD_REPO_SSH_URL scaffold
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,8 @@ jobs:
                 # for feature branches, add the commit hash
                 export RELEASE_VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM
             fi
+            # Set the version in pyproject.toml
+            poetry version $RELEASE_VERSION
             # Save version to a file that will be persisted
             echo "$RELEASE_VERSION" > version.txt
       - run:
@@ -105,10 +107,7 @@ jobs:
             echo "Tag: $CIRCLE_TAG"
       - run:
           name: Build a distributable package with Poetry
-          command: |
-            RELEASE_VERSION=$(cat version.txt)
-            poetry version $RELEASE_VERSION
-            poetry build
+          command: poetry build
       - store_artifacts:
           path: dist
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,9 @@ jobs:
           name: Set version
           command: |
             if [[ $CIRCLE_TAG ]]; then
+                # This is a tagged release, version has been handled upstream
                 export RELEASE_VERSION=$CIRCLE_TAG
+            # Otherwise, relies on a dev version like "1.2.1.dev" by default
             elif [[ $CIRCLE_BRANCH == << pipeline.parameters.publish-branch >> ]]; then
                 # for main branches, can't add the commit hash since it's not a valid format for publishing
                 export RELEASE_VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM
@@ -96,8 +98,6 @@ jobs:
                 # for feature branches, add the commit hash
                 export RELEASE_VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM+${CIRCLE_SHA1:0:7}
             fi
-            # Set the version in pyproject.toml
-            poetry version $RELEASE_VERSION
             # Save version to a file that will be persisted
             echo "$RELEASE_VERSION" > version.txt
       - run:
@@ -107,10 +107,14 @@ jobs:
             echo "Building a wheel release with version $RELEASE_VERSION"
             echo "Build number: $CIRCLE_BUILD_NUM"
             echo "Commit hash: ${CIRCLE_SHA1:0:7}"
-            echo "Tag: $CIRCLE_TAG"
+            echo "Git tag: $CIRCLE_TAG"
       - run:
-          name: Build a distributable package with Poetry
-          command: poetry build
+          name: Build a distributable package as a wheel release with Poetry
+          command: |
+            RELEASE_VERSION=$(cat version.txt)
+            # Set the version in pyproject.toml
+            poetry version $RELEASE_VERSION
+            poetry build
       - store_artifacts:
           path: dist
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,17 +151,6 @@ jobs:
               --data '{ "ref": "main", "variables": [{"key": "SITE", "value": "dev" }, {"key": "APP", "value": "hydra"}, {"key": "TAGS", "value": "light" }, {"key": "PACKAGE_VERSION", "value": "$PACKAGE_VERSION" }] }' \
               https://gitlab.com/api/v4/projects/${GITLAB_PROJECT_ID}/pipeline
 
-  publish:
-    docker:
-      - image: cimg/python:<< pipeline.parameters.python-version >>
-    steps:
-      - attach_workspace:
-          at: .
-      - run:
-          name: Publish on PyPI
-          command: |
-            poetry publish --username "${PYPI_USERNAME}" --password "${PYPI_PASSWORD}" --no-interaction
-
 workflows:
   build:
     jobs:
@@ -188,16 +177,6 @@ workflows:
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
-      - deploy:
-          requires:
-            - build
-          filters:
-            branches:
-              only:
-                - main
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*/
-          context: org-global
       - publish:
           requires:
             - build
@@ -207,6 +186,16 @@ workflows:
                 - << pipeline.parameters.publish-branch >>
                 - /[0-9]+(\.[0-9]+)+/
                 - /rc[0-9]+/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+          context: org-global
+      - deploy:
+          requires:
+            - publish
+          filters:
+            branches:
+              only:
+                - main
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
           context: org-global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,12 +89,9 @@ jobs:
           command: |
             if [[ $CIRCLE_TAG ]]; then
                 export RELEASE_VERSION=$CIRCLE_TAG
-            elif [[ $CIRCLE_BRANCH == << pipeline.parameters.publish-branch >> ]]; then
-                # for main branches, can't add the commit hash since it's not a valid format for publishing
-                export RELEASE_VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM
             else
                 # for feature branches, add the commit hash
-                export RELEASE_VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM+${CIRCLE_SHA1:0:7}
+                export RELEASE_VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM
             fi
             # Save version to a file that will be persisted
             echo "$RELEASE_VERSION" > version.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,6 +155,17 @@ jobs:
               --form "variables[PACKAGE_VERSION]=${VERSION}" \
               https://gitlab.com/api/v4/projects/${GITLAB_PROJECT_ID}/trigger/pipeline
 
+  publish:
+    docker:
+      - image: cimg/python:<< pipeline.parameters.python-version >>
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Publish on PyPI
+          command: |
+            poetry publish --username "${PYPI_USERNAME}" --password "${PYPI_PASSWORD}" --no-interaction
+
 workflows:
   build:
     jobs:
@@ -181,6 +192,16 @@ workflows:
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - main
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+          context: org-global
       - publish:
           requires:
             - build
@@ -190,13 +211,6 @@ workflows:
                 - << pipeline.parameters.publish-branch >>
                 - /[0-9]+(\.[0-9]+)+/
                 - /rc[0-9]+/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*/
-          context: org-global
-      - deploy:
-          requires:
-            - build
-          filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
           context: org-global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,18 +142,14 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Trigger GitLab CI pipeline to deploy
+          name: Create a GitLab CI pipeline for deploying
           command: | # https://docs.gitlab.com/ee/api/pipeline_triggers.html
             source .env_vars
-            echo "Triggering a GitLab Pipeline to deploy Hydra version $VERSION on dev with tag light..."
+            echo "Create a GitLab CI pipeline for deploying Hydra version $VERSION on dev with tag light..."
             curl --request POST \
-              --form token=${GITLAB_PIPELINE_TOKEN} \
-              --form ref=main \
-              --form "variables[SITE]=dev" \
-              --form "variables[APP]=hydra" \
-              --form "variables[TAGS]=light" \
-              --form "variables[PACKAGE_VERSION]=${VERSION}" \
-              https://gitlab.com/api/v4/projects/${GITLAB_PROJECT_ID}/trigger/pipeline
+              --header "PRIVATE-TOKEN: ${GITLAB_PRIVATE_TOKEN}" \
+              --data '{ "ref": "main", "variables": [{"key": "SITE", "value": "dev.data.gouv.fr" }, {"key": "APP", "value": "hydra"}, {"key": "TAGS", "value": "light" }] }' \
+              https://gitlab.com/api/v4/projects/${GITLAB_PROJECT_ID}/pipeline
 
   publish:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,9 +89,12 @@ jobs:
           command: |
             if [[ $CIRCLE_TAG ]]; then
                 export RELEASE_VERSION=$CIRCLE_TAG
+            elif [[ $CIRCLE_BRANCH == << pipeline.parameters.publish-branch >> ]]; then
+                # for main branches, can't add the commit hash since it's not a valid format for publishing
+                export RELEASE_VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM
             else
                 # for feature branches, add the commit hash
-                export RELEASE_VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM
+                export RELEASE_VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM+${CIRCLE_SHA1:0:7}
             fi
             # Set the version in pyproject.toml
             poetry version $RELEASE_VERSION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,18 +91,18 @@ jobs:
           name: Set the version number
           command: |
             if [[ $CIRCLE_TAG ]]; then
-                export VERSION=$CIRCLE_TAG
+                export PACKAGE_VERSION=$CIRCLE_TAG
             elif [[ $CIRCLE_BRANCH == << pipeline.parameters.publish-branch >> ]]; then
                 # for main branches, can't add the commit hash since it's not a valid format for publishing
-                export VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM
+                export PACKAGE_VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM
             else
                 # for feature branches, add the commit hash
-                export VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM+${CIRCLE_SHA1:0:7}
+                export PACKAGE_VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM+${CIRCLE_SHA1:0:7}
             fi
             # Display some debug info
-            echo "Building a wheel release with version $VERSION, build number: $CIRCLE_BUILD_NUM, commit hash: ${CIRCLE_SHA1:0:7}, tag: $CIRCLE_TAG."
+            echo "Building a wheel release with version $PACKAGE_VERSION, build number: $CIRCLE_BUILD_NUM, commit hash: ${CIRCLE_SHA1:0:7}, tag: $CIRCLE_TAG."
             # Save the version number in a file
-            echo "export VERSION=\"$VERSION\"" >> .env_vars
+            echo "export PACKAGE_VERSION=\"$PACKAGE_VERSION\"" >> .env_vars
       - run:
           name: Build a distributable package
           command: |
@@ -114,7 +114,7 @@ jobs:
                 poetry build
             else
                 # Relies on a dev version like "1.2.1.dev" by default
-                poetry version $VERSION
+                poetry version $PACKAGE_VERSION
                 poetry build
             fi
       - store_artifacts:
@@ -145,10 +145,10 @@ jobs:
           name: Create a GitLab CI pipeline for deploying
           command: | # https://docs.gitlab.com/ee/api/pipeline_triggers.html
             source .env_vars
-            echo "Create a GitLab CI pipeline for deploying Hydra version $VERSION on dev with tag light..."
+            echo "Create a GitLab CI pipeline for deploying Hydra version $PACKAGE_VERSION on dev with tag light..."
             curl --request POST \
               --header "PRIVATE-TOKEN: ${GITLAB_PRIVATE_TOKEN}" \
-              --data '{ "ref": "main", "variables": [{"key": "SITE", "value": "dev.data.gouv.fr" }, {"key": "APP", "value": "hydra"}, {"key": "TAGS", "value": "light" }] }' \
+              --data '{ "ref": "main", "variables": [{"key": "SITE", "value": "dev" }, {"key": "APP", "value": "hydra"}, {"key": "TAGS", "value": "light" }, {"key": "PACKAGE_VERSION", "value": "$PACKAGE_VERSION" }] }' \
               https://gitlab.com/api/v4/projects/${GITLAB_PROJECT_ID}/pipeline
 
   publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,6 @@ jobs:
           command: |
             poetry config virtualenvs.in-project true
             poetry install
-      - run:
-          name: Save commit hash in a file
-          command: echo $CIRCLE_SHA1 > .git-commit
       - save_cache:
           key: << pipeline.parameters.cache-prefix >>-{{ arch }}-{{ checksum "poetry.lock" }}
           paths:
@@ -88,33 +85,27 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Set the version number
-          command: |
-            if [[ $CIRCLE_TAG ]]; then
-                export PACKAGE_VERSION=$CIRCLE_TAG
-            elif [[ $CIRCLE_BRANCH == << pipeline.parameters.publish-branch >> ]]; then
-                # for main branches, can't add the commit hash since it's not a valid format for publishing
-                export PACKAGE_VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM
-            else
-                # for feature branches, add the commit hash
-                export PACKAGE_VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM+${CIRCLE_SHA1:0:7}
-            fi
-            # Display some debug info
-            echo "Building a wheel release with version $PACKAGE_VERSION, build number: $CIRCLE_BUILD_NUM, commit hash: ${CIRCLE_SHA1:0:7}, tag: $CIRCLE_TAG."
-            # Save the version number in a file
-            echo "export PACKAGE_VERSION=\"$PACKAGE_VERSION\"" >> .env_vars
-      - run:
           name: Build a distributable package
           command: |
-            # Get the version number
-            source .env_vars
+            # Set the version
+            if [[ $CIRCLE_TAG ]]; then
+                export VERSION=$CIRCLE_TAG
+            elif [[ $CIRCLE_BRANCH == << pipeline.parameters.publish-branch >> ]]; then
+                # for main branches, can't add the commit hash since it's not a valid format for publishing
+                export VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM
+            else
+                # for feature branches, add the commit hash
+                export VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM+${CIRCLE_SHA1:0:7}
+            fi
+            # Display some debug info
+            echo "Building a wheel release with version $VERSION, build number: $CIRCLE_BUILD_NUM, commit hash: ${CIRCLE_SHA1:0:7}, tag: $CIRCLE_TAG."
             # Build a wheel release
             if [[ $CIRCLE_TAG ]]; then
                 # This is a tagged release, version has been handled upstream
                 poetry build
             else
                 # Relies on a dev version like "1.2.1.dev" by default
-                poetry version $PACKAGE_VERSION
+                poetry version $VERSION
                 poetry build
             fi
       - store_artifacts:
@@ -134,22 +125,6 @@ jobs:
           name: Publish on PyPI
           command: |
             poetry publish --username "${PYPI_USERNAME}" --password "${PYPI_PASSWORD}" --no-interaction
-
-  deploy:
-    docker:
-      - image: cimg/python:<< pipeline.parameters.python-version >>
-    steps:
-      - attach_workspace:
-          at: .
-      - run:
-          name: Create a GitLab CI pipeline for deploying
-          command: | # https://docs.gitlab.com/ee/api/pipeline_triggers.html
-            source .env_vars
-            echo "Create a GitLab CI pipeline for deploying Hydra version $PACKAGE_VERSION on dev with tag light..."
-            curl --request POST \
-              --header "PRIVATE-TOKEN: ${GITLAB_PRIVATE_TOKEN}" \
-              --data '{ "ref": "main", "variables": [{"key": "SITE", "value": "dev" }, {"key": "APP", "value": "hydra"}, {"key": "TAGS", "value": "light" }, {"key": "PACKAGE_VERSION", "value": "$PACKAGE_VERSION" }] }' \
-              https://gitlab.com/api/v4/projects/${GITLAB_PROJECT_ID}/pipeline
 
 workflows:
   build:
@@ -186,16 +161,6 @@ workflows:
                 - << pipeline.parameters.publish-branch >>
                 - /[0-9]+(\.[0-9]+)+/
                 - /rc[0-9]+/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*/
-          context: org-global
-      - deploy:
-          requires:
-            - publish
-          filters:
-            branches:
-              only:
-                - main
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
           context: org-global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
             echo "Commit hash: ${CIRCLE_SHA1:0:7}"
             echo "Tag: $CIRCLE_TAG"
       - run:
-          name: Build package
+          name: Build a distributable package
           command: |
             RELEASE_VERSION=$(cat version.txt)
             if [[ $CIRCLE_TAG ]]; then
@@ -160,11 +160,11 @@ jobs:
           command: |
             git clone --quiet --depth 1 $SCAFFOLD_REPO_SSH_URL scaffold
       - run:
-          name: Trigger Gitlab CI/CD pipeline
+          name: Trigger Gitlab CI/CD pipeline for Hydra to deploy to dev environment
           command: |
             RELEASE_VERSION=$(cat version.txt)
             cd scaffold
-            ./scripts/gitlab-ci-pipeline.sh hydra $RELEASE_VERSION prod ""
+            ./scripts/gitlab-ci-pipeline.sh hydra $RELEASE_VERSION dev ""
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
             ./scripts/gitlab-ci-pipeline.sh hydra $RELEASE_VERSION dev ""
 
 workflows:
-  build:
+  build-test-deploy:
     jobs:
       - install:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,15 +5,18 @@ parameters:
   python-version:
     type: string
     default: "3.11.9"
-  python-module:
-    type: string
-    default: "udata_hydra"
   publish-branch:
     type: string
     default: "main"
+    description: "Branch to publish to PyPi and trigger the Gitlab CI/CD pipeline when pushed to"
+  deploy-env:
+    type: string
+    default: "dev"
+    description: "Environment to deploy to"
   cache-prefix:
     type: string
     default: "py-cache-v2"
+    description: "Prefix used for cache keys to store and restore Python dependencies. Increment this value to invalidate existing caches."
 
 jobs:
   install:
@@ -170,9 +173,9 @@ jobs:
             # The script args are, in order:
             # - hydra: the name of the project to deploy (APP_NAME)
             # - $RELEASE_VERSION: the version to deploy (RELEASE_VERSION)
-            # - env: the environment to deploy to (ENV)
+            # - << pipeline.parameters.deploy-env >>: the environment to deploy to (ENV)
             # - "": the deploy variables (VARS)
-            ./scripts/gitlab-ci-pipeline.sh hydra $RELEASE_VERSION dev ""
+            ./scripts/gitlab-ci-pipeline.sh hydra $RELEASE_VERSION << pipeline.parameters.deploy-env >> ""
 
 workflows:
   build-test-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,9 @@ jobs:
           command: |
             poetry config virtualenvs.in-project true
             poetry install
+      - run:
+          name: Save commit hash in a file
+          command: echo $CIRCLE_SHA1 > .git-commit
       - save_cache:
           key: << pipeline.parameters.cache-prefix >>-{{ arch }}-{{ checksum "poetry.lock" }}
           paths:
@@ -85,9 +88,8 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Build a distributable package
+          name: Set the version number
           command: |
-            # Set the version
             if [[ $CIRCLE_TAG ]]; then
                 export VERSION=$CIRCLE_TAG
             elif [[ $CIRCLE_BRANCH == << pipeline.parameters.publish-branch >> ]]; then
@@ -99,6 +101,13 @@ jobs:
             fi
             # Display some debug info
             echo "Building a wheel release with version $VERSION, build number: $CIRCLE_BUILD_NUM, commit hash: ${CIRCLE_SHA1:0:7}, tag: $CIRCLE_TAG."
+            # Save the version number in a file
+            echo "export VERSION=\"$VERSION\"" >> .env_vars
+      - run:
+          name: Build a distributable package
+          command: |
+            # Get the version number
+            source .env_vars
             # Build a wheel release
             if [[ $CIRCLE_TAG ]]; then
                 # This is a tagged release, version has been handled upstream
@@ -125,16 +134,25 @@ jobs:
           name: Publish on PyPI
           command: |
             poetry publish --username "${PYPI_USERNAME}" --password "${PYPI_PASSWORD}" --no-interaction
+
+  deploy:
+    docker:
+      - image: cimg/python:<< pipeline.parameters.python-version >>
+    steps:
+      - attach_workspace:
+          at: .
       - run:
           name: Trigger GitLab CI pipeline to deploy
           command: | # https://docs.gitlab.com/ee/api/pipeline_triggers.html
+            source .env_vars
+            echo "Triggering a GitLab Pipeline to deploy Hydra version $VERSION on dev with tag light..."
             curl --request POST \
               --form token=${GITLAB_PIPELINE_TOKEN} \
               --form ref=main \
               --form "variables[SITE]=dev" \
               --form "variables[APP]=hydra" \
               --form "variables[TAGS]=light" \
-              --form "variables[PACKAGE_VERSION]=$(poetry version -s)" \
+              --form "variables[PACKAGE_VERSION]=${VERSION}" \
               https://gitlab.com/api/v4/projects/${GITLAB_PROJECT_ID}/trigger/pipeline
 
 workflows:
@@ -172,6 +190,13 @@ workflows:
                 - << pipeline.parameters.publish-branch >>
                 - /[0-9]+(\.[0-9]+)+/
                 - /rc[0-9]+/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+          context: org-global
+      - deploy:
+          requires:
+            - build
+          filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
           context: org-global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,27 +85,37 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Build a distributable package
+          name: Set version
           command: |
-            # Set the version
             if [[ $CIRCLE_TAG ]]; then
-                export VERSION=$CIRCLE_TAG
+                export RELEASE_VERSION=$CIRCLE_TAG
             elif [[ $CIRCLE_BRANCH == << pipeline.parameters.publish-branch >> ]]; then
                 # for main branches, can't add the commit hash since it's not a valid format for publishing
-                export VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM
+                export RELEASE_VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM
             else
                 # for feature branches, add the commit hash
-                export VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM+${CIRCLE_SHA1:0:7}
+                export RELEASE_VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM+${CIRCLE_SHA1:0:7}
             fi
-            # Display some debug info
-            echo "Building a wheel release with version $VERSION, build number: $CIRCLE_BUILD_NUM, commit hash: ${CIRCLE_SHA1:0:7}, tag: $CIRCLE_TAG."
-            # Build a wheel release
+            # Save version to a file that will be persisted
+            echo "$RELEASE_VERSION" > version.txt
+      - run:
+          name: Display build info for debugging
+          command: |
+            RELEASE_VERSION=$(cat version.txt)
+            echo "Building a wheel release with version $RELEASE_VERSION"
+            echo "Build number: $CIRCLE_BUILD_NUM"
+            echo "Commit hash: ${CIRCLE_SHA1:0:7}"
+            echo "Tag: $CIRCLE_TAG"
+      - run:
+          name: Build package
+          command: |
+            RELEASE_VERSION=$(cat version.txt)
             if [[ $CIRCLE_TAG ]]; then
                 # This is a tagged release, version has been handled upstream
                 poetry build
             else
                 # Relies on a dev version like "1.2.1.dev" by default
-                poetry version $VERSION
+                poetry version $RELEASE_VERSION
                 poetry build
             fi
       - store_artifacts:
@@ -114,6 +124,7 @@ jobs:
           root: .
           paths:
             - .
+            - version.txt
 
   publish:
     docker:
@@ -125,6 +136,35 @@ jobs:
           name: Publish on PyPI
           command: |
             poetry publish --username "${PYPI_USERNAME}" --password "${PYPI_PASSWORD}" --no-interaction
+
+  trigger-gitlab-pipeline:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Configure the SSH deploy private key
+          command: |
+            mkdir -p ~/.ssh
+            echo "$DEPLOY_PRIVATE_KEY" > ~/.ssh/id_ed25519
+            chmod 600 ~/.ssh/id_ed25519
+            ssh-keyscan -t rsa gitlab.com >> ~/.ssh/known_hosts
+      - run:
+          name: Configure Git
+          command: |
+            git config --global user.email "root@data.gouv.fr"
+            git config --global user.name "datagouv"
+      - run:
+          name: Clone scaffold repository
+          command: |
+            git clone --quiet --depth 1 $SCAFFOLD_REPO_SSH_URL scaffold
+      - run:
+          name: Trigger Gitlab CI/CD pipeline
+          command: |
+            RELEASE_VERSION=$(cat version.txt)
+            cd scaffold
+            ./scripts/gitlab-ci-pipeline.sh hydra $RELEASE_VERSION prod ""
 
 workflows:
   build:
@@ -164,3 +204,13 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
           context: org-global
+      - trigger-gitlab-pipeline:
+          requires:
+            - publish
+          filters:
+            branches:
+              only:
+                - << pipeline.parameters.publish-branch >>
+          context:
+            - org-global
+            - gitlab-trigger

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,17 @@ jobs:
           name: Publish on PyPI
           command: |
             poetry publish --username "${PYPI_USERNAME}" --password "${PYPI_PASSWORD}" --no-interaction
+      - run:
+          name: Trigger GitLab CI pipeline to deploy
+          command: | # https://docs.gitlab.com/ee/api/pipeline_triggers.html
+            curl --request POST \
+              --form token=${GITLAB_PIPELINE_TOKEN} \
+              --form ref=main \
+              --form "variables[SITE]=dev" \
+              --form "variables[APP]=hydra" \
+              --form "variables[TAGS]=light" \
+              --form "variables[PACKAGE_VERSION]=$(poetry version -s)" \
+              https://gitlab.com/api/v4/projects/${GITLAB_PROJECT_ID}/trigger/pipeline
 
 workflows:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - Add a `quiet` argument for `purge_check` and `purge_csv_table` CLIs [#184](https://github.com/datagouv/hydra/pull/184)
 - Fix wrong resource status [#187](https://github.com/datagouv/hydra/pull/187)
 - More informative error relative to check resource CLI [#188](https://github.com/datagouv/hydra/pull/188)
+- Trigger GitLab deployment in CI when pushing on `main` [#186](https://github.com/datagouv/hydra/pull/186)
 
 ## 2.0.0 (2024-09-24)
 


### PR DESCRIPTION
Closes https://github.com/datagouv/data.gouv.fr/issues/1465.
Goes hand-to-hand with the GitLab MR.

For now, the trigger is sent only when we push on `main`.
We can imagine other policies?

**EDIT:**

Refactored entirely to use the GitLab _scaffolding_ deploy script repository instead, as the intermediary between this CI and GitLab API for infra repo CI.

Remarks:
- As a first version, this only triggers a call to the deploy script (and thus to GitLab for deploying on dev environment) when pushing on main. Later, we can imagine deploying easily, I suggest to do it in another PR.
- This PR also includes a better separation of the build job into smaller steps, clearer and easier to debug. This cleaning job can be more clearly done in this dedicated [PR #238](https://github.com/datagouv/hydra/pull/238), so if easier to review we can review and merge [#238](https://github.com/datagouv/hydra/pull/238) before the present one 
- Once merged, we will do the same thing on repo udata and any other suggested
- This has been partially tested, it successfully triggers the simple-scaffold script: https://app.circleci.com/pipelines/github/datagouv/hydra/1765/workflows/d04e28c0-7bf3-481f-af57-c0f660be8ab0/jobs/6328. It needs to be rested with the full workflow, once the GitLab API integration in CI is ready on infra's side.