### PR TITLE
fix: fix wrong resource status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix CSV analysis CLI [#181](https://github.com/datagouv/hydra/pull/181)
 - Add a `PUT` `/api/resources-exceptions/{id}` route to update a resource exception [#178](https://github.com/datagouv/hydra/pull/178)
 - Add a `quiet` argument for `purge_check` and `purge_csv_table` CLIs [#184](https://github.com/datagouv/hydra/pull/184)
+- Fix wrong resource status [#187](https://github.com/datagouv/hydra/pull/187)
 
 ## 2.0.0 (2024-09-24)
 

--- a/udata_hydra/crawl/check_resources.py
+++ b/udata_hydra/crawl/check_resources.py
@@ -118,8 +118,8 @@ async def check_resource(
                 },
             )
 
-            # Update resource status to TO_PROCESS_RESOURCE
-            await Resource.update(resource_id, data={"status": "TO_PROCESS_RESOURCE"})
+            # Update resource status to TO_ANALYSE_RESOURCE
+            await Resource.update(resource_id, data={"status": "TO_ANALYSE_RESOURCE"})
 
             # Enqueue the resource for analysis
             queue.enqueue(analyse_resource, check["id"], is_first_check, _priority=worker_priority)

--- a/udata_hydra/db/resource.py
+++ b/udata_hydra/db/resource.py
@@ -11,7 +11,6 @@ class Resource:
         "BACKOFF": "backoff period for this domain, will be checked later",
         "CRAWLING_URL": "resource URL currently being crawled",
         "TO_ANALYSE_RESOURCE": "resource to be processed for change, type and size analysis",
-        "ANALYSING_RESOURCE": "currently being processed for change, type and size analysis",
         "TO_ANALYSE_CSV": "resource content to be analysed by CSV detective",
         "ANALYSING_CSV": "resource content currently being analysed by CSV detective",
         "INSERTING_IN_DB": "currently being inserted in DB",


### PR DESCRIPTION
Fix Sentry issue https://errors.data.gouv.fr/organizations/sentry/issues/145139/:

- A resource status was not the right one among valid resource statuses
- One resource status was not being used