### PR TITLE
fix: fix empty table indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Current (in progress)
 
 - Fix wrong resource status [#196](https://github.com/datagouv/hydra/pull/196)
+- Fix issue related to empty `table_indexes` column instead of default `{}` [#197](https://github.com/datagouv/hydra/pull/197)
+
 
 ## 2.0.3 (2024-10-22)
 

--- a/tests/test_api/test_api_resources_exceptions.py
+++ b/tests/test_api/test_api_resources_exceptions.py
@@ -83,6 +83,7 @@ async def test_create_resource_exception(
     assert resp.status == 201
     data: dict = await resp.json()
     assert data["resource_id"] == RESOURCE_ID
+    assert data["table_indexes"] == "{}"
 
 
 async def test_update_resource_exception(

--- a/udata_hydra/analysis/csv.py
+++ b/udata_hydra/analysis/csv.py
@@ -130,13 +130,8 @@ async def analyse_csv(
     # If it is, get the table_indexes to use them later
     exception: Record | None = await ResourceException.get_by_resource_id(resource_id)
     table_indexes: dict | None = None
-    if exception:
-        try:
-            table_indexes: dict | None = json.loads(exception["table_indexes"])
-        except TypeError:
-            raise TypeError(
-                f"table_indexes should be a JSON object, got {exception.get('table_indexes')}"
-            )
+    if exception and exception.get("table_indexes"):
+        table_indexes = json.loads(exception["table_indexes"])
 
     timer = Timer("analyse-csv")
     assert any(_ is not None for _ in (check_id, url))

--- a/udata_hydra/analysis/csv.py
+++ b/udata_hydra/analysis/csv.py
@@ -129,7 +129,14 @@ async def analyse_csv(
     # Check if the resource is in the exceptions table
     # If it is, get the table_indexes to use them later
     exception: Record | None = await ResourceException.get_by_resource_id(resource_id)
-    table_indexes: dict | None = json.loads(exception["table_indexes"]) if exception else None
+    table_indexes: dict | None = None
+    if exception:
+        try:
+            table_indexes: dict | None = json.loads(exception["table_indexes"])
+        except TypeError:
+            raise TypeError(
+                f"table_indexes should be a JSON object, got {exception.get('table_indexes')}"
+            )
 
     timer = Timer("analyse-csv")
     assert any(_ is not None for _ in (check_id, url))
@@ -238,7 +245,12 @@ def compute_create_table_query(
             else:
                 if index_type == "index":
                     index_name = f"{table_name}_{slugify(col_name)}_idx"
-                    table.append_constraint(Index(index_name, col_name))
+                    try:
+                        table.append_constraint(Index(index_name, col_name))
+                    except KeyError:
+                        raise KeyError(
+                            f'Error creating index "{index_name}" on column "{col_name}". Does the column "{col_name}" exist in the table?'
+                        )
                 # TODO: other index types. Not easy with sqlalchemy, maybe use raw sql?
 
     compiled_query = CreateTable(table).compile(dialect=asyncpg.dialect())

--- a/udata_hydra/db/resource_exception.py
+++ b/udata_hydra/db/resource_exception.py
@@ -63,9 +63,7 @@ class ResourceException:
                 VALUES ($1, $2, $3)
                 RETURNING *;
             """
-            return await connection.fetchrow(
-                q, resource_id, json.dumps(table_indexes) if table_indexes else None, comment
-            )
+            return await connection.fetchrow(q, resource_id, json.dumps(table_indexes), comment)
 
     @classmethod
     async def update(
@@ -100,9 +98,7 @@ class ResourceException:
                 WHERE resource_id = $1
                 RETURNING *;
             """
-            return await connection.fetchrow(
-                q, resource_id, json.dumps(table_indexes) if table_indexes else None, comment
-            )
+            return await connection.fetchrow(q, resource_id, json.dumps(table_indexes), comment)
 
     @classmethod
     async def delete(cls, resource_id: str) -> None:


### PR DESCRIPTION
Closes https://github.com/datagouv/hydra/issues/198:

- Don't put empty values in `tables_indexes` columns of `resources_exceptions` table in the DB inser/update requests (happening when POSTing/PUTing `resources_exceptions`)
- Add test case to test the value when it's set to None
- Add a few exceptions catching related to `resources_exceptions` on the go, to secure the code

Note: the production table has been already updated so that all `resources_exceptions` have "{}" as the empty value (same as the default SQL value) when empty, so the error is already fixed with the current `resources_exceptions`:
`UPDATE resources_exceptions SET table_indexes = '{}' WHERE table_indexes IS NULL;`