### PR TITLE
fix: fix bad requests errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The token is configured in the `config.toml` file as `API_KEY`, and has a defaul
 If you're using hydra as an external service to receive resource events from [udata](https://github.com/opendatateam/udata), then udata needs to also configure this
 API key in its `udata.cfg` file:
 
-```
+```python
 # Wether udata should publish the resource events
 PUBLISH_ON_RESOURCE_EVENTS = True
 # Where to publish the events

--- a/udata_hydra/routes/checks.py
+++ b/udata_hydra/routes/checks.py
@@ -64,10 +64,8 @@ async def create_check(request: web.Request) -> web.Response:
     try:
         payload: dict = await request.json()
         resource_id: str = payload["resource_id"]
-    except ValidationError as err:
-        raise web.HTTPBadRequest(text=json.dumps(err.messages))
-    except KeyError as e:
-        raise web.HTTPBadRequest(text=f"Missing key: {str(e)}")
+    except Exception as err:
+        raise web.HTTPBadRequest(text=json.dumps({"error": str(err)}))
 
     # Get URL from resource_id
     try:

--- a/udata_hydra/routes/resources.py
+++ b/udata_hydra/routes/resources.py
@@ -66,8 +66,8 @@ async def create_resource(request: web.Request) -> web.Response:
     try:
         payload = await request.json()
         valid_payload: dict = ResourceSchema().load(payload)
-    except ValidationError as err:
-        raise web.HTTPBadRequest(text=json.dumps(err.messages))
+    except Exception as err:
+        raise web.HTTPBadRequest(text=json.dumps({"error": str(err)}))
 
     document: dict | None = valid_payload["document"]
     if not document:
@@ -96,8 +96,8 @@ async def update_resource(request: web.Request) -> web.Response:
     try:
         payload = await request.json()
         valid_payload: dict = ResourceSchema().load(payload)
-    except ValidationError as err:
-        raise web.HTTPBadRequest(text=json.dumps(err.messages))
+    except Exception as err:
+        raise web.HTTPBadRequest(text=json.dumps({"error": str(err)}))
 
     document: dict | None = valid_payload["document"]
     if not document:

--- a/udata_hydra/routes/resources_exceptions.py
+++ b/udata_hydra/routes/resources_exceptions.py
@@ -76,8 +76,8 @@ async def update_resource_exception(request: web.Request) -> web.Response:
             valid, error = ResourceExceptionSchema.are_table_indexes_valid(table_indexes)
             if not valid:
                 raise web.HTTPBadRequest(text=error)
-    except Exception as e:
-        raise web.HTTPBadRequest(text=f"error: {str(e)}")
+    except Exception as err:
+        raise web.HTTPBadRequest(text=json.dumps({"error": str(err)}))
 
     resource_exception: Record = await ResourceException.update(
         resource_id=resource_id,

--- a/udata_hydra/routes/resources_legacy.py
+++ b/udata_hydra/routes/resources_legacy.py
@@ -31,8 +31,8 @@ async def create_resource_legacy(request: web.Request) -> web.Response:
     try:
         payload = await request.json()
         valid_payload: dict = ResourceSchema().load(payload)
-    except ValidationError as err:
-        raise web.HTTPBadRequest(text=json.dumps(err.messages))
+    except Exception as err:
+        raise web.HTTPBadRequest(text=json.dumps({"error": str(err)}))
 
     resource: dict = valid_payload["document"]
     if not resource:
@@ -60,8 +60,8 @@ async def update_resource_legacy(request: web.Request) -> web.Response:
     try:
         payload = await request.json()
         valid_payload: dict = ResourceSchema().load(payload)
-    except ValidationError as err:
-        raise web.HTTPBadRequest(text=json.dumps(err.messages))
+    except Exception as err:
+        raise web.HTTPBadRequest(text=json.dumps({"error": str(err)}))
 
     resource: dict = valid_payload["document"]
     if not resource:
@@ -79,8 +79,8 @@ async def delete_resource_legacy(request: web.Request) -> web.Response:
     try:
         payload = await request.json()
         valid_payload: dict = ResourceSchema().load(payload)
-    except ValidationError as err:
-        raise web.HTTPBadRequest(text=json.dumps(err.messages))
+    except Exception as err:
+        raise web.HTTPBadRequest(text=json.dumps({"error": str(err)}))
 
     resource_id: str = valid_payload["resource_id"]
 


### PR DESCRIPTION
Fix [this Sentry error](https://errors.data.gouv.fr/organizations/sentry/issues/145725/?query=json&referrer=issue-stream&statsPeriod=14d) when sending malformed request, and uniformize API error responses.