### PR TITLE
ci: fix deprecated CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,6 @@ jobs:
             poetry publish --username "${PYPI_USERNAME}" --password "${PYPI_PASSWORD}" --no-interaction
 
 workflows:
-  version: 2
   build:
     jobs:
       - install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - deploy:
+      - run:
           name: Publish on PyPI
           command: |
             poetry publish --username "${PYPI_USERNAME}" --password "${PYPI_PASSWORD}" --no-interaction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix minor types issues [#204](https://github.com/datagouv/hydra/pull/204)
 - Return resources statuses count in crawler status endpoint response [#206](https://github.com/datagouv/hydra/pull/206)
+- Fix deprecated CircleCI config [#207](https://github.com/datagouv/hydra/pull/207)
 
 ## 2.0.4 (2024-10-28)
 


### PR DESCRIPTION
- Change deprecated Circle step name from `deploy`to `run`(see https://circleci.com/docs/migrate-from-deploy-to-run/)
- Remove workflows version key, which is deprecated since CircleCI 2.1 (see https://circleci.com/docs/configuration-reference/#workflow-version)