### PR TITLE
docs: update docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Return resources statuses count in crawler status endpoint response [#206](https://github.com/datagouv/hydra/pull/206)
 - Fix deprecated CircleCI config [#207](https://github.com/datagouv/hydra/pull/207)
 - Fix Sentry issue #4195 [#209](https://github.com/datagouv/hydra/pull/209)
+- Clean doctrings for more consistent style [#215](https://github.com/datagouv/hydra/pull/215)
 
 ## 2.0.4 (2024-10-28)
 

--- a/udata_hydra/analysis/csv.py
+++ b/udata_hydra/analysis/csv.py
@@ -285,13 +285,13 @@ async def csv_to_parquet(
     Convert a csv file to parquet using inspection data.
 
     Args:
-        :file_path: CSV file path to convert
-        :inspection: CSV detective report
-        :table_name: used to name the parquet file
+        file_path: CSV file path to convert.
+        inspection: CSV detective report.
+        table_name: used to name the parquet file.
 
     Returns:
-        :parquet_url: URL of the parquet file
-        :parquet_size: size of the parquet file
+        parquet_url: URL of the parquet file.
+        parquet_size: size of the parquet file.
     """
     if not config.CSV_TO_PARQUET:
         log.debug("CSV_TO_PARQUET turned off, skipping parquet export.")

--- a/udata_hydra/crawl/helpers.py
+++ b/udata_hydra/crawl/helpers.py
@@ -22,8 +22,7 @@ async def get_content_type_from_header(headers: dict) -> str:
 
 
 def convert_headers(headers: CIMultiDictProxy) -> dict:
-    """
-    Convert headers from aiohttp CIMultiDict type to dict type
+    """Convert headers from aiohttp CIMultiDict type to dict type.
 
     :warning: this will only take the first value for a given header key but multidict is not json serializable
     """
@@ -68,7 +67,10 @@ async def is_domain_backoff(domain: str) -> tuple[bool, str]:
     """Check if we should not crawl on this domain, in order to avoid 429 errors/bans as much as we can. We backoff if:
     - we have hit a 429
     - we have hit the rate limit on our side
-    Returns a tuple with if it should backoff or not (boolean) and the reason why (string)
+
+    Returns:
+        A boolean indicating if it should backoff or not
+        A string with the message why we should backoff
     """
     backoff: tuple = (False, "")
 

--- a/udata_hydra/utils/auth.py
+++ b/udata_hydra/utils/auth.py
@@ -24,13 +24,13 @@ def token_auth_middleware(
     Token auth middleware that checks the "Authorization" http header for token and, if the token in the requet headers is valid, then middleware adds the user to request with key that contain the "request_property" variable, else it will raise an HTTPForbiddenexception.
 
     Args:
-        request_property (str, optional): Key for save in request object.
+        request_property: Key for save in request object.
             Defaults to 'user'.
-        auth_scheme (str, optional): Prefix for value in "Authorization" header.
+        auth_scheme: Prefix for value in "Authorization" header.
             Defaults to 'Bearer'.
-        exclude_routes: (tuple, optional): Tuple of pathes that will be excluded.
+        exclude_routes: Tuple of pathes that will be excluded.
             Defaults to empty tuple.
-        exclude_methods(tuple, optional): Tuple of http methods that will be
+        exclude_methods: Tuple of http methods that will be
             excluded. Defaults to empty tuple.
 
     Raises:
@@ -38,7 +38,7 @@ def token_auth_middleware(
         web.HTTPForbidden: Wrong token, schema or header.
 
     Returns:
-        Coroutine: Aiohttp middleware.
+        Aiohttp middleware.
     """
 
     @web.middleware


### PR DESCRIPTION
Rewrite a few docstrings to use a more consistent syntax.

Since we use type hints extensively, we don't need to rewrite the types in the docstring, so we decided use the quite broadly standard [Google styleguide](https://google.github.io/styleguide/pyguide.html) for docstrings.