### PR TITLE
fix: fix get all checks CRUD method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Clean doctrings for more consistent style [#215](https://github.com/datagouv/hydra/pull/215)
 - Fix some type hints [#214](https://github.com/datagouv/hydra/pull/214)
 - Add option to force analysis even if resource has not changed[#205](https://github.com/datagouv/hydra/pull/205)
+- Fix get all checks CRUD method [#217](https://github.com/datagouv/hydra/pull/217)
 
 ## 2.0.4 (2024-10-28)
 

--- a/udata_hydra/db/check.py
+++ b/udata_hydra/db/check.py
@@ -63,8 +63,8 @@ class Check:
             SELECT catalog.id as catalog_id, checks.id as check_id,
                 catalog.status as catalog_status, checks.status as check_status, catalog.deleted as deleted, *
             FROM checks, catalog
-            WHERE checks.id = catalog.last_check
-            AND catalog.{column} = $1
+            WHERE catalog.{column} = $1
+            AND checks.id = catalog.last_check
             """
             return await connection.fetchrow(q, url or resource_id)
 
@@ -78,7 +78,7 @@ class Check:
                 catalog.status as catalog_status, checks.status as check_status, catalog.deleted as deleted, *
             FROM checks, catalog
             WHERE catalog.{column} = $1
-            AND catalog.url = checks.url
+            AND catalog.{column} = checks.{column}
             ORDER BY created_at DESC
             """
             return await connection.fetch(q, url or resource_id)

--- a/udata_hydra/routes/checks.py
+++ b/udata_hydra/routes/checks.py
@@ -4,7 +4,6 @@ from datetime import date
 import aiohttp
 from aiohttp import web
 from asyncpg import Record
-from marshmallow import ValidationError
 
 from udata_hydra import config, context
 from udata_hydra.crawl.check_resources import check_resource


### PR DESCRIPTION
Fix the 3rd issue in https://github.com/datagouv/data.gouv.fr/issues/1518.
This fixes the behaviour of the `/checks/all` endpoint, which was the only method using the `Check.get_all` CRUD method.

Also:
- remove useless import
- minor SQL order rewrite for better consistency with other SQL queries