### PR TITLE
fix: refactor ParseError to enrich Sentry with context and to inquire about Sentry errors like #4096

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix Sentry issue #4096 regarding duplicate columns names [#218](https://github.com/datagouv/hydra/pull/218)
 
 ## 2.0.5 (2024-11-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Fix Sentry issue #4096 regarding duplicate columns names [#218](https://github.com/datagouv/hydra/pull/218)
+- Refactor ParseError to enrich Sentry with context and to inquire about Sentry errors like #4096  [#218](https://github.com/datagouv/hydra/pull/218)
 
 ## 2.0.5 (2024-11-08)
 

--- a/tests/test_parquet_export.py
+++ b/tests/test_parquet_export.py
@@ -6,9 +6,9 @@ import pytest
 
 from udata_hydra.analysis.csv import (
     RESERVED_COLS,
+    csv_detective_routine,
     csv_to_parquet,
     generate_records,
-    perform_csv_inspection,
 )
 from udata_hydra.utils.parquet import save_as_parquet
 
@@ -26,7 +26,9 @@ pytestmark = pytest.mark.asyncio
 async def test_save_as_parquet(file_and_count):
     filename, expected_count = file_and_count
     file_path = f"tests/data/{filename}"
-    inspection: dict | None = await perform_csv_inspection(file_path)
+    inspection: dict | None = csv_detective_routine(
+        csv_file_path=file_path, output_profile=True, num_rows=-1, save_results=False
+    )
     assert inspection
     columns = inspection["columns"]
     columns = {
@@ -54,7 +56,9 @@ async def test_save_as_parquet(file_and_count):
 async def test_csv_to_parquet(mocker, parquet_config):
     async def execute_csv_to_parquet() -> tuple[str, int] | None:
         file_path = "tests/data/catalog.csv"
-        inspection: dict | None = await perform_csv_inspection(file_path)
+        inspection: dict | None = csv_detective_routine(
+            csv_file_path=file_path, output_profile=True, num_rows=-1, save_results=False
+        )
         assert inspection
         return await csv_to_parquet(
             file_path=file_path, inspection=inspection, table_name="test_table"

--- a/udata_hydra/analysis/csv.py
+++ b/udata_hydra/analysis/csv.py
@@ -159,7 +159,7 @@ async def analyse_csv(
 
         # Launch csv-detective against given file
         try:
-            csv_inspection: dict = csv_detective_routine(
+            csv_inspection: dict | None = csv_detective_routine(
                 csv_file_path=tmp_file.name, output_profile=True, num_rows=-1, save_results=False
             )
         except Exception as e:

--- a/udata_hydra/analysis/csv.py
+++ b/udata_hydra/analysis/csv.py
@@ -7,7 +7,6 @@ import sys
 from datetime import datetime, timezone
 from typing import Any, Iterator
 
-import sentry_sdk
 from asyncpg import Record
 from csv_detective.detection import engine_to_file
 from csv_detective.explore_csv import routine as csv_detective_routine
@@ -33,7 +32,7 @@ from str2float import str2float
 
 from udata_hydra import config, context
 from udata_hydra.analysis import helpers
-from udata_hydra.analysis.errors import ParseException
+from udata_hydra.analysis.errors import ParseException, handle_parse_exception
 from udata_hydra.db import compute_insert_query
 from udata_hydra.db.check import Check
 from udata_hydra.db.resource import Resource
@@ -157,7 +156,17 @@ async def analyse_csv(
 
     try:
         await Check.update(check["id"], {"parsing_started_at": datetime.now(timezone.utc)})
-        csv_inspection = await perform_csv_inspection(tmp_file.name)
+
+        # Launch csv-detective against given file
+        try:
+            csv_inspection: dict = csv_detective_routine(
+                csv_file_path=tmp_file.name, output_profile=True, num_rows=-1, save_results=False
+            )
+        except Exception as e:
+            raise ParseException(
+                step="csv_detective", resource_id=resource_id, url=url, check_id=check_id
+            ) from e
+
         timer.mark("csv-inspection")
 
         await csv_to_db(
@@ -369,9 +378,9 @@ async def csv_to_db(
     try:
         await db.execute(q)
     except Exception as e:
-        raise type(e)(
-            f"Error creating table {table_name} from ressource ID {resource_id}: {str(e)}"
-        )
+        raise ParseException(
+            step="create_table_query", resource_id=resource_id, table_name=table_name
+        ) from e
 
     # this use postgresql COPY from an iterator, it's fast but might be difficult to debug
     if not debug_insert:
@@ -383,7 +392,9 @@ async def csv_to_db(
                 columns=columns.keys(),
             )
         except Exception as e:  # I know what I'm doing, pinky swear
-            raise ParseException("copy_records_to_table") from e
+            raise ParseException(
+                step="copy_records_to_table", resource_id=resource_id, table_name=table_name
+            ) from e
     # this inserts rows from iterator one by one, slow but useful for debugging
     else:
         bar = ProgressBar(total=inspection["total_lines"])
@@ -407,41 +418,7 @@ async def csv_to_db_index(table_name: str, inspection: dict, check: Record) -> N
     )
 
 
-async def perform_csv_inspection(file_path: str) -> dict | None:
-    """Launch csv-detective against given file"""
-    try:
-        return csv_detective_routine(
-            file_path, output_profile=True, num_rows=-1, save_results=False
-        )
-    except Exception as e:
-        raise ParseException("csv_detective") from e
-
-
 async def delete_table(table_name: str) -> None:
     db = await context.pool("csv")
     await db.execute(f'DROP TABLE IF EXISTS "{table_name}"')
     await db.execute("DELETE FROM tables_index WHERE parsing_table = $1", table_name)
-
-
-async def handle_parse_exception(e: Exception, table_name: str, check: Record | None) -> None:
-    """Specific ParsingError handling. Enriches sentry w/ context if available,
-    and store error if in a check context. Also cleanup :table_name: if needed."""
-    db = await context.pool("csv")
-    await db.execute(f'DROP TABLE IF EXISTS "{table_name}"')
-    if check:
-        if config.SENTRY_DSN:
-            with sentry_sdk.push_scope() as scope:
-                scope.set_extra("check_id", check["id"])
-                scope.set_extra("csv_url", check["url"])
-                scope.set_extra("resource_id", check["resource_id"])
-                event_id = sentry_sdk.capture_exception(e)
-        # e.__cause__ let us access the "inherited" error of ParseException (raise e from cause)
-        # it's called explicit exception chaining and it's very cool, look it up (PEP 3134)!
-        err = f"{e.step}:sentry:{event_id}" if config.SENTRY_DSN else f"{e.step}:{str(e.__cause__)}"
-        await Check.update(
-            check["id"],
-            {"parsing_error": err, "parsing_finished_at": datetime.now(timezone.utc)},
-        )
-        log.error("Parsing error", exc_info=e)
-    else:
-        raise e

--- a/udata_hydra/analysis/errors.py
+++ b/udata_hydra/analysis/errors.py
@@ -1,4 +1,62 @@
+import logging
+from datetime import datetime, timezone
+from tkinter import N
+
+import sentry_sdk
+from asyncpg import Record
+
+from udata_hydra import config, context
+from udata_hydra.db.check import Check
+
+log = logging.getLogger("udata-hydra")
+
+
 class ParseException(Exception):
-    def __init__(self, step, *args: object) -> None:
-        self.step = step
+    """
+    Exception raised when an error occurs during parsing.
+    Enriches Sentry with tags if available.
+    """
+
+    def __init__(
+        self,
+        step: str | None = None,
+        resource_id: str | None = None,
+        url: str | None = None,
+        check_id: int | None = None,
+        table_name: str | None = None,
+        *args,
+    ) -> None:
+        if step:
+            self.step = step
+        if config.SENTRY_DSN:
+            with sentry_sdk.push_scope() as scope:
+                scope.set_tags(
+                    {
+                        "resource_id": resource_id or "unknown",
+                        "csv_url": url or "unknown",
+                        "check_id": check_id or "unknown",
+                        "table_name": table_name or "unknown",
+                    }
+                )
         super().__init__(*args)
+
+
+async def handle_parse_exception(e: ParseException, table_name: str, check: Record | None) -> None:
+    """Specific ParsingError handling. Enriches Sentry w/ tags if available,
+    and store error if in a check context. Also cleanup :table_name: if needed."""
+    db = await context.pool("csv")
+    await db.execute(f'DROP TABLE IF EXISTS "{table_name}"')
+    if check:
+        if config.SENTRY_DSN:
+            with sentry_sdk.push_scope():
+                event_id = sentry_sdk.capture_exception(e)
+        # e.__cause__ let us access the "inherited" error of ParseException (raise e from cause)
+        # it's called explicit exception chaining and it's very cool, look it up (PEP 3134)!
+        err = f"{e.step}:sentry:{event_id}" if config.SENTRY_DSN else f"{e.step}:{str(e.__cause__)}"
+        await Check.update(
+            check["id"],
+            {"parsing_error": err, "parsing_finished_at": datetime.now(timezone.utc)},
+        )
+        log.error("Parsing error", exc_info=e)
+    else:
+        raise e

--- a/udata_hydra/analysis/errors.py
+++ b/udata_hydra/analysis/errors.py
@@ -43,7 +43,7 @@ class ParseException(Exception):
 
 
 async def handle_parse_exception(e: ParseException, table_name: str, check: Record | None) -> None:
-    """Specific ParsingError handling. Store error if in a check context. Also cleanup :table_name: if needed."""
+    """Specific ParseException handling. Store error if in a check context. Also cleanup :table_name: if needed."""
     db = await context.pool("csv")
     await db.execute(f'DROP TABLE IF EXISTS "{table_name}"')
     if check:

--- a/udata_hydra/analysis/errors.py
+++ b/udata_hydra/analysis/errors.py
@@ -29,7 +29,8 @@ class ParseException(Exception):
         if step:
             self.step = step
         if config.SENTRY_DSN:
-            with sentry_sdk.push_scope() as scope:
+            with sentry_sdk.new_scope() as scope:
+                # scope.set_level("warning")
                 scope.set_tags(
                     {
                         "resource_id": resource_id or "unknown",
@@ -48,7 +49,7 @@ async def handle_parse_exception(e: ParseException, table_name: str, check: Reco
     await db.execute(f'DROP TABLE IF EXISTS "{table_name}"')
     if check:
         if config.SENTRY_DSN:
-            with sentry_sdk.push_scope():
+            with sentry_sdk.new_scope():
                 event_id = sentry_sdk.capture_exception(e)
         # e.__cause__ let us access the "inherited" error of ParseException (raise e from cause)
         # it's called explicit exception chaining and it's very cool, look it up (PEP 3134)!

--- a/udata_hydra/analysis/errors.py
+++ b/udata_hydra/analysis/errors.py
@@ -43,8 +43,7 @@ class ParseException(Exception):
 
 
 async def handle_parse_exception(e: ParseException, table_name: str, check: Record | None) -> None:
-    """Specific ParsingError handling. Enriches Sentry w/ tags if available,
-    and store error if in a check context. Also cleanup :table_name: if needed."""
+    """Specific ParsingError handling. Store error if in a check context. Also cleanup :table_name: if needed."""
     db = await context.pool("csv")
     await db.execute(f'DROP TABLE IF EXISTS "{table_name}"')
     if check:


### PR DESCRIPTION
- Refactor ParseError as a generic exception to enrich Sentry with context and to inquire about Sentry errors like [#4096](https://errors.data.gouv.fr/organizations/sentry/issues/4096) when analysing CSV and creating DB tables
- Update deprecated Sentry SDK method `set_extra()` to `set_tags()`
- Update deprecated Sentry SDK method `push_scope()` to `new_scope()`
