### PR TITLE
fix: fix type issue regarding resource_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Remove legacy routes [#203](https://github.com/datagouv/hydra/pull/203)
 - More explicit error reporting when sending to udata without raising errors for udata responding with a 404 [#213](https://github.com/datagouv/hydra/pull/213)
 - Minor cleaning: remove unused arg in function [#219](https://github.com/datagouv/hydra/pull/219)
+- Fix type issue regarding `resource_id` [#220](https://github.com/datagouv/hydra/pull/220)
 
 ## 2.0.5 (2024-11-08)
 

--- a/udata_hydra/analysis/csv.py
+++ b/udata_hydra/analysis/csv.py
@@ -125,7 +125,7 @@ async def analyse_csv(
     if not check:
         log.error("No check found or URL provided")
         return
-    resource_id = check["resource_id"]
+    resource_id: str = str(check["resource_id"])
     url = check["url"]
 
     # Update resource status to ANALYSING_CSV


### PR DESCRIPTION
Fix typing issue, as `resource_id` was a `UUID` type instead of a `string` when passed to several methods, including the `ParseException` constructor.