### PR TITLE
feat: add commit hash as a build env var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,10 +85,8 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Export commit hash to environment variable
-          command: |
-            echo "export COMMIT_HASH=${CIRCLE_SHA1:0:7}" >> $BASH_ENV
-            source $BASH_ENV
+          name: Write commit hash to version file
+          command: echo "__commit__ = \"${CIRCLE_SHA1:0:7}\"" > udata_hydra/commit.py
       - run:
           name: Set the version
           command: |
@@ -106,14 +104,13 @@ jobs:
             echo "Building a wheel release with version $VERSION"
             echo "Build number: $CIRCLE_BUILD_NUM"
             echo "Tag: $CIRCLE_TAG"
-            echo "Commit hash: $COMMIT_HASH"
-            echo "BASH_ENV contents:"
-            cat $BASH_ENV
+            echo "Commit hash: ${CIRCLE_SHA1:0:7}"
+            echo "Commit file content:"
+            cat udata_hydra/commit.py || echo "commit.py file not found"
       - run:
           name: Build a distributable package
           command: |
-            # Pass the commit hash as a build-time environment variable
-            COMMIT_HASH=$COMMIT_HASH poetry build
+            poetry build
       - store_artifacts:
           path: dist
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,29 +85,29 @@ jobs:
       - attach_workspace:
           at: .
       - run:
+          name: Export commit hash to environment variable
+          command: |
+            echo "export COMMIT_HASH=${CIRCLE_SHA1:0:7}" >> $BASH_ENV
+            source $BASH_ENV
+      - run:
           name: Build a distributable package
           command: |
             # Set the version
             if [[ $CIRCLE_TAG ]]; then
                 export VERSION=$CIRCLE_TAG
-            elif [[ $CIRCLE_BRANCH == << pipeline.parameters.publish-branch >> ]]; then
-                # for main branches, can't add the commit hash since it's not a valid format for publishing
+            else; then
                 export VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM
-            else
-                # for feature branches, add the commit hash
-                export VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM+${CIRCLE_SHA1:0:7}
             fi
             # Display some debug info
             echo "Building a wheel release with version $VERSION, build number: $CIRCLE_BUILD_NUM, commit hash: ${CIRCLE_SHA1:0:7}, tag: $CIRCLE_TAG."
-            # Build a wheel release
-            if [[ $CIRCLE_TAG ]]; then
-                # This is a tagged release, version has been handled upstream
-                poetry build
-            else
-                # Relies on a dev version like "1.2.1.dev" by default
+            # Set version if this is not a tagged release
+            # For tagged releases, the version is set upstream
+            # Otherwise, it relies on a dev version like "1.2.1.dev" by default
+            if [[ ! $CIRCLE_TAG ]]; then
                 poetry version $VERSION
-                poetry build
             fi
+            # Build while passing the commit hash as a build-time environment variable
+            COMMIT_HASH=$COMMIT_HASH poetry build
       - store_artifacts:
           path: dist
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,23 +90,29 @@ jobs:
             echo "export COMMIT_HASH=${CIRCLE_SHA1:0:7}" >> $BASH_ENV
             source $BASH_ENV
       - run:
-          name: Build a distributable package
+          name: Set the version
           command: |
-            # Set the version
-            if [[ $CIRCLE_TAG ]]; then
-                export VERSION=$CIRCLE_TAG
-            else; then
-                export VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM
-            fi
-            # Display some debug info
-            echo "Building a wheel release with version $VERSION, build number: $CIRCLE_BUILD_NUM, commit hash: ${CIRCLE_SHA1:0:7}, tag: $CIRCLE_TAG."
-            # Set version if this is not a tagged release
             # For tagged releases, the version is set upstream
             # Otherwise, it relies on a dev version like "1.2.1.dev" by default
-            if [[ ! $CIRCLE_TAG ]]; then
+            if [[ $CIRCLE_TAG ]]; then
+                export VERSION=$CIRCLE_TAG
+            else
+                export VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM
                 poetry version $VERSION
             fi
-            # Build while passing the commit hash as a build-time environment variable
+      - run:
+          name: Display build info for debugging
+          command: |
+            echo "Building a wheel release with version $VERSION"
+            echo "Build number: $CIRCLE_BUILD_NUM"
+            echo "Tag: $CIRCLE_TAG"
+            echo "Commit hash: $COMMIT_HASH"
+            echo "BASH_ENV contents:"
+            cat $BASH_ENV
+      - run:
+          name: Build a distributable package
+          command: |
+            # Pass the commit hash as a build-time environment variable
             COMMIT_HASH=$COMMIT_HASH poetry build
       - store_artifacts:
           path: dist

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dmypy.json
 
 # Project specific
 config.toml
+commit.py

--- a/udata_hydra/__init__.py
+++ b/udata_hydra/__init__.py
@@ -34,6 +34,8 @@ class Configurator:
         # add project metadata to config
         self.configuration["APP_NAME"] = "udata-hydra"
         self.configuration["APP_VERSION"] = importlib.metadata.version("udata-hydra")
+        # Add commit hash from environment variable
+        self.configuration["COMMIT_HASH"] = os.environ.get("COMMIT_HASH", "unknown")
 
     def override(self, **kwargs) -> None:
         self.configuration.update(kwargs)

--- a/udata_hydra/__init__.py
+++ b/udata_hydra/__init__.py
@@ -5,6 +5,11 @@ from pathlib import Path
 
 import tomllib
 
+try:
+    from commit import __commit__
+except ImportError:
+    __commit__ = "unknown"
+
 log = logging.getLogger("udata-hydra")
 
 
@@ -34,8 +39,8 @@ class Configurator:
         # add project metadata to config
         self.configuration["APP_NAME"] = "udata-hydra"
         self.configuration["APP_VERSION"] = importlib.metadata.version("udata-hydra")
-        # Add commit hash from environment variable
-        self.configuration["COMMIT_HASH"] = os.environ.get("COMMIT_HASH", "unknown")
+        # Add commit hash from commit.py file
+        self.configuration["COMMIT_HASH"] = __commit__
 
     def override(self, **kwargs) -> None:
         self.configuration.update(kwargs)

--- a/udata_hydra/routes/status.py
+++ b/udata_hydra/routes/status.py
@@ -147,5 +147,6 @@ async def get_health(request: web.Request) -> web.Response:
         {
             "version": config.APP_VERSION,
             "environment": config.ENVIRONMENT or "unknown",
+            "commit_hash": config.COMMIT_HASH,
         }
     )


### PR DESCRIPTION
Display the commit hash in health check and remove it from the version string in anycase.

Adding the commit hash to the version string was problematic:
1) We couldn't publish a version string including a commit hash, as it doesn't follow the PyPi version string format, so we couldn't see the commit for published released from main. So for many release, we couldn't use this useful debug feature.
2) We had to create special rules in CI depending on the release, to add it or not
3) It's not as easy to check the version number in CircleCI as checking the healthcheck

I finally figured out how to retrieve the commit hash easily in the CI, using $BASH_ENV.
Hence this PR:

- Pass the commit hash to an env var in the CI
- Build the app with then commit hash env var as environment context
- Use the commit hash env var in the health check code
- Simplify the CI by building the version number without the commit hash in any case: not need to have different rule depending on CIRCLE_BRANCH and CIRCLE_TAG
- Separate the CI into smaller steps, easier to debug
- Add a dedicated "Display build info for debugging" step