### PR TITLE
ci: parellelize tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,15 +82,13 @@ jobs:
             # Find and split tests
             TESTFILES=$(find tests -name "test_*.py" | circleci tests split --split-by=timings)
             # Debug: Show what's in TESTFILES
-            echo "Files assigned to this executor:"
+            echo "Test files assigned to the executor ${CIRCLE_NODE_INDEX}/${CIRCLE_NODE_TOTAL}:"
             echo "$TESTFILES"
             # Run the found tests
             if [ -n "$TESTFILES" ]; then
-              echo "Running tests: $TESTFILES"
               poetry run pytest --junitxml=reports/python/tests.xml -p no:sugar --color=yes $TESTFILES
             else
               echo "No tests to run in this split"
-              find tests -name "test_*.py" | wc -l
               exit 1
             fi
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,9 +85,8 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Build a distributable package
+          name: Set the version
           command: |
-            # Set the version
             if [[ $CIRCLE_TAG ]]; then
                 export VERSION=$CIRCLE_TAG
             elif [[ $CIRCLE_BRANCH == << pipeline.parameters.publish-branch >> ]]; then
@@ -97,8 +96,17 @@ jobs:
                 # for feature branches, add the commit hash
                 export VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM+${CIRCLE_SHA1:0:7}
             fi
-            # Display some debug info
-            echo "Building a wheel release with version $VERSION, build number: $CIRCLE_BUILD_NUM, commit hash: ${CIRCLE_SHA1:0:7}, tag: $CIRCLE_TAG."
+      - run:
+          name: Display build info for debugging
+          command: |
+            echo "Building a wheel release with version $VERSION"
+            echo "Build number: $CIRCLE_BUILD_NUM"
+            echo "Tag: $CIRCLE_TAG"
+            echo "Commit hash: $COMMIT_HASH"
+            echo "Version: $VERSION"
+      - run:
+          name: Build a distributable package
+          command: |
             # Build a wheel release
             if [[ $CIRCLE_TAG ]]; then
                 # This is a tagged release, version has been handled upstream

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,28 +89,27 @@ jobs:
           command: |
             if [[ $CIRCLE_TAG ]]; then
                 # This is a tagged release, version has been handled upstream
-                export VERSION=$CIRCLE_TAG
+                export RELEASE_VERSION=$CIRCLE_TAG
             # Otherwise, relies on a dev version like "1.2.1.dev" by default
             elif [[ $CIRCLE_BRANCH == << pipeline.parameters.publish-branch >> ]]; then
                 # for main branches, can't add the commit hash since it's not a valid format for publishing
-                export VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM
+                export RELEASE_VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM
             else
                 # for feature branches, add the commit hash
-                export VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM+${CIRCLE_SHA1:0:7}
+                export RELEASE_VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM+${CIRCLE_SHA1:0:7}
             fi
             # Set the version in pyproject.toml
-            poetry version $VERSION
+            poetry version $RELEASE_VERSION
       - run:
           name: Display build info for debugging
           command: |
-            echo "Building a wheel release with version $VERSION"
+            echo "Building a wheel release with version $RELEASE_VERSION"
             echo "Build number: $CIRCLE_BUILD_NUM"
             echo "Commit hash: ${CIRCLE_SHA1:0:7}"
             echo "Git tag: $CIRCLE_TAG"
       - run:
           name: Build a distributable package as a wheel release with Poetry
-          command: |
-            poetry build
+          command: poetry build
       - store_artifacts:
           path: dist
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
             poetry publish --username "${PYPI_USERNAME}" --password "${PYPI_PASSWORD}" --no-interaction
 
 workflows:
-  build:
+  build-test-publish:
     jobs:
       - install:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
           POSTGRES_DB: postgres
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
+    parallelism: 4 # Number of executed tests in parallel
     steps:
       - attach_workspace:
           at: .
@@ -75,7 +76,20 @@ jobs:
             DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
             UDATA_INSTANCE_NAME: udata
           command: |
-            poetry run pytest --junitxml=reports/python/tests.xml -p no:sugar --color=yes
+            # Find and split tests
+            TESTFILES=$(find tests -name "test_*.py" | circleci tests split --split-by=timings)
+            # Debug: Show what's in TESTFILES
+            echo "Files assigned to this executor:"
+            echo "$TESTFILES"
+            # Run the found tests
+            if [ -n "$TESTFILES" ]; then
+              echo "Running tests: $TESTFILES"
+              poetry run pytest --junitxml=reports/python/tests.xml -p no:sugar --color=yes $TESTFILES
+            else
+              echo "No tests to run in this split"
+              find tests -name "test_*.py" | wc -l
+              exit 1
+            fi
       - store_test_results:
           path: reports/python
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,8 @@ jobs:
                 # for feature branches, add the commit hash
                 export RELEASE_VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM+${CIRCLE_SHA1:0:7}
             fi
+            # Save version to a file that will be persisted
+            echo "$RELEASE_VERSION" > version.txt
       - run:
           name: Display build info for debugging
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,9 @@ jobs:
           name: Set the version
           command: |
             if [[ $CIRCLE_TAG ]]; then
+                # This is a tagged release, version has been handled upstream
                 export VERSION=$CIRCLE_TAG
+            # Otherwise, relies on a dev version like "1.2.1.dev" by default
             elif [[ $CIRCLE_BRANCH == << pipeline.parameters.publish-branch >> ]]; then
                 # for main branches, can't add the commit hash since it's not a valid format for publishing
                 export VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM
@@ -96,26 +98,19 @@ jobs:
                 # for feature branches, add the commit hash
                 export VERSION=$(poetry version -s)$CIRCLE_BUILD_NUM+${CIRCLE_SHA1:0:7}
             fi
+            # Set the version in pyproject.toml
+            poetry version $VERSION
       - run:
           name: Display build info for debugging
           command: |
             echo "Building a wheel release with version $VERSION"
             echo "Build number: $CIRCLE_BUILD_NUM"
-            echo "Tag: $CIRCLE_TAG"
-            echo "Commit hash: $COMMIT_HASH"
-            echo "Version: $VERSION"
+            echo "Commit hash: ${CIRCLE_SHA1:0:7}"
+            echo "Git tag: $CIRCLE_TAG"
       - run:
-          name: Build a distributable package
+          name: Build a distributable package as a wheel release with Poetry
           command: |
-            # Build a wheel release
-            if [[ $CIRCLE_TAG ]]; then
-                # This is a tagged release, version has been handled upstream
-                poetry build
-            else
-                # Relies on a dev version like "1.2.1.dev" by default
-                poetry version $VERSION
-                poetry build
-            fi
+            poetry build
       - store_artifacts:
           path: dist
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
             - << pipeline.parameters.cache-prefix >>-{{ arch }}-{{ checksum "poetry.lock" }}
             - << pipeline.parameters.cache-prefix >>-{{ arch }}-{{ .Branch }}
             - << pipeline.parameters.cache-prefix >>-{{ arch }}-{{ .Environment.BASE_BRANCH }}
+            - << pipeline.parameters.cache-prefix >>-{{ arch }}-
       - run:
           name: Install python dependencies
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Add CLI util to insert or update a resource into the catalog (change since last catalog load) [#228](https://github.com/datagouv/hydra/pull/228)
 - Fix deadlocks errors when purging CSV tables by refactoring `purge_csv_tables` to use atomic transactions [#230](https://github.com/datagouv/hydra/pull/230)
 - Improve timing of checks depending on changes since last check [#163](https://github.com/datagouv/hydra/pull/163)
-- Simplify the build CI step [#238](https://github.com/datagouv/hydra/pull/238)
+- Parallelize tests in CI [#238](https://github.com/datagouv/hydra/pull/238)
 
 ## 2.0.5 (2024-11-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Add CLI util to insert or update a resource into the catalog (change since last catalog load) [#228](https://github.com/datagouv/hydra/pull/228)
 - Fix deadlocks errors when purging CSV tables by refactoring `purge_csv_tables` to use atomic transactions [#230](https://github.com/datagouv/hydra/pull/230)
 - Improve timing of checks depending on changes since last check [#163](https://github.com/datagouv/hydra/pull/163)
-
+- Simplify the build CI step [#238](https://github.com/datagouv/hydra/pull/238)
 
 ## 2.0.5 (2024-11-08)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,8 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "catalog_harvested: use catalog_harvested.csv as source",
 ]
-addopts = "--cov=udata_hydra/ --cov-report term-missing --cov-fail-under=88"
+# addopts = "--cov=udata_hydra/ --cov-report term-missing --cov-fail-under=89" # if we want to fail if coverage is less than 89%
+addopts = "--cov=udata_hydra/ --cov-report term-missing"
 
 [tool.ruff]
 lint = { extend-select = ["I"], ignore = ["F401"] } # ["I"] is to also sort imports with an isort rule # TODO: remove ignore F401 later


### PR DESCRIPTION
- Add install step cache fallback

- Parallelize the execution of tests among 4 CircleCI executors. This results in a gain of an average approx. ~40% on the total CI execution time (around 60% specifically on the tests job)
    - Note 1: For this, we need to deactivate the maximum coverage rule for test success, as each executor reach a different coverage. The gain makes it worth to deactivate this feature, as anyway we can monitor the coverage, and we can activate the minimum coverage threshold when running locally if necessary.
    - Note 2: it has also been tested with 2 executors, 3 executors and 10 executors, but 4 executors seems like a good balance for time gains

Before:
![Screenshot 2024-12-20 at 20 32 49](https://github.com/user-attachments/assets/95548aa8-0c32-44c5-ab88-23a8f21cb045)

After:
![Screenshot 2024-12-20 at 20 32 38](https://github.com/user-attachments/assets/fcc5f878-ced2-4413-8aa1-0bbf9d596f13)