### PR TITLE
ci: use a bash file instead of text file to store env vars across CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,21 +112,20 @@ jobs:
           command: |
             if [[ $CIRCLE_TAG ]]; then
                 # This is a tagged release, version has been handled upstream
-                export RELEASE_VERSION=$CIRCLE_TAG
+                echo "export RELEASE_VERSION=$CIRCLE_TAG" > version.sh
             # Otherwise, relies on a dev version like "1.2.1.dev" by default
             elif [[ $CIRCLE_BRANCH == << pipeline.parameters.publish-branch >> ]]; then
                 # for main branches, can't add the commit hash since it's not a valid format for publishing
-                export RELEASE_VERSION=$(./poetry-binary version -s)$CIRCLE_BUILD_NUM
+                echo "export RELEASE_VERSION=$(./poetry-binary version -s)$CIRCLE_BUILD_NUM" > version.sh
             else
                 # for feature branches, add the commit hash
-                export RELEASE_VERSION=$(./poetry-binary version -s)$CIRCLE_BUILD_NUM+${CIRCLE_SHA1:0:7}
+                echo "export RELEASE_VERSION=$(./poetry-binary version -s)$CIRCLE_BUILD_NUM+${CIRCLE_SHA1:0:7}" > version.sh
             fi
-            # Save version to a file that will be persisted
-            echo "$RELEASE_VERSION" > version.txt
+            chmod +x version.sh
       - run:
           name: Display build info for debugging
           command: |
-            RELEASE_VERSION=$(cat version.txt)
+            source version.sh
             echo "Building a wheel release with version $RELEASE_VERSION"
             echo "Build number: $CIRCLE_BUILD_NUM"
             echo "Commit hash: ${CIRCLE_SHA1:0:7}"
@@ -134,7 +133,7 @@ jobs:
       - run:
           name: Build a distributable package as a wheel release with Poetry
           command: |
-            RELEASE_VERSION=$(cat version.txt)
+            source version.sh
             # Set the version in pyproject.toml
             ./poetry-binary version $RELEASE_VERSION
             ./poetry-binary build
@@ -144,7 +143,7 @@ jobs:
           root: .
           paths:
             - .
-            - version.txt
+            - version.sh
 
   publish:
     docker:
@@ -184,7 +183,7 @@ jobs:
       - run:
           name: Trigger Gitlab CI/CD pipeline for Hydra to deploy to dev environment
           command: |
-            RELEASE_VERSION=$(cat version.txt)
+            source version.sh
             cd scaffold
             # Run the script that triggers the Gitlab CI/CD pipeline.
             # Must have GITLAB_API_TOKEN set in the environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Parallelize tests in CI [#238](https://github.com/datagouv/hydra/pull/238)
 - Refactor analysis logic to remove 5 non necessary queries, using the existing data in the code instead of re-querying it [#227](https://github.com/datagouv/hydra/pull/227)
 - Use a package-manager-agnostic pyproject.toml instead of a Poetry pyproject.toml [#170](https://github.com/datagouv/hydra/pull/170)
+- Use a bash file instead of text file to store env vars across CI jobs [#245](https://github.com/datagouv/hydra/pull/245)
 
 ## 2.0.5 (2024-11-08)
 


### PR DESCRIPTION
Use a bash file instead of text file to store env vars across CI jobs, as it is cleaner and more idiomatic.