### PR TITLE
ci: add a CI job to create a release on Sentry so we can track deploy…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,28 @@ jobs:
             - .
             - version.sh
 
+  create-sentry-release:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Create Sentry release
+          command: |
+            source version.sh
+            # Create release
+            curl https://errors.data.gouv.fr/api/0/organizations/sentry/releases/ \
+              -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
+              -H 'Content-Type: application/json' \
+              -d "{\"version\":\"${RELEASE_VERSION}\",\"ref\":\"${CIRCLE_SHA1}\",\"projects\":[\"hydra\"]}"
+
+            # Create deployment
+            curl https://errors.data.gouv.fr/api/0/organizations/sentry/releases/${RELEASE_VERSION}/deploys/ \
+              -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
+              -H 'Content-Type: application/json' \
+              -d "{\"environment\":\"<< pipeline.parameters.deploy-env >>\"}"
+
   publish:
     docker:
       - image: cimg/python:<< pipeline.parameters.python-version >>
@@ -243,3 +265,14 @@ workflows:
           context:
             - org-global
             - gitlab-trigger
+      - create-sentry-release:
+          requires:
+            - trigger-gitlab-pipeline
+          filters:
+            branches:
+              only:
+                - << pipeline.parameters.publish-branch >>
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+          context:
+            - org-global


### PR DESCRIPTION
Add a CI job to create a release on Sentry so we can track deployments on Sentry, and better track the regressions.
Will track the version deployed, the commit used for deployed, and the environment.