### PR TITLE
Restore Sentry details in extras

### DIFF
--- a/udata_hydra/analysis/csv.py
+++ b/udata_hydra/analysis/csv.py
@@ -37,8 +37,8 @@ from udata_hydra.db.check import Check
 from udata_hydra.db.resource import Resource
 from udata_hydra.db.resource_exception import ResourceException
 from udata_hydra.utils import (
-    ParseException,
     IOException,
+    ParseException,
     Reader,
     Timer,
     download_resource,
@@ -155,7 +155,7 @@ async def analyse_csv(
             )
         except Exception as e:
             raise ParseException(
-                step="csv_detective", resource_id=resource_id, url=url, check_id=check["id"],
+                step="csv_detective", resource_id=resource_id, url=url, check_id=check["id"]
             ) from e
         timer.mark("csv-inspection")
 
@@ -179,7 +179,7 @@ async def analyse_csv(
             timer.mark("csv-to-parquet")
         except Exception as e:
             raise ParseException(
-                step="parquet_export", resource_id=resource_id, url=url, check_id=check["id"],
+                step="parquet_export", resource_id=resource_id, url=url, check_id=check["id"]
             ) from e
 
         check = await Check.update(


### PR DESCRIPTION
This was an attempt to understand and fix the reason why Sentry event ids are not properly sent to udata (results are for instance `"parsing_error": "csv_detective:sentry:None"`). Context:
- Sentry stuff is handled [here](https://github.com/datagouv/hydra/blob/main/udata_hydra/utils/errors.py)
- during the whole process, when `hydra` crashes, we raise `ParseException` or `IOException` which both inherit from `ExceptionWithSentryDetails`
- these parts of the code are encapsulated into bigger try/except, which then call [`handle_parse_exception`](https://github.com/datagouv/hydra/blob/5754831893219ae50e481e0c2508b90f27a72c44/udata_hydra/utils/errors.py#L57), where we do `event_id = sentry_sdk.capture_exception(e)` which can indeed return `None` in specific cases (see [source](https://github.com/getsentry/sentry-python/blob/0d23b726b6b47b81acc2a1d2ba359d845467c71d/sentry_sdk/scope.py#L1235)), so this could be our case