### PR TITLE
Reset stuck statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add a status resetting mechanism for stuck resources [#251](https://github.com/datagouv/hydra/pull/251)
 
 ## 2.1.1 (2025-03-12)
 

--- a/tests/test_crawl/test_crawl.py
+++ b/tests/test_crawl/test_crawl.py
@@ -713,29 +713,18 @@ async def test_wrong_url_in_catalog(
         (config.STUCK_THRESHOLD_SECONDS * 2, True),
     ],
 )
-async def test_reset_statuses(
-    fake_check, db, setup_catalog, duration_params
-):
+async def test_reset_statuses(fake_check, db, setup_catalog, duration_params):
     """Reset the status of a resource stuck for a while"""
     check_duration, should_reset = duration_params
     await fake_check(
         resource_id=RESOURCE_ID, created_at=datetime.now() - timedelta(seconds=check_duration)
     )
     status = "ANALYSING_CSV"
-    await db.execute(
-        f"UPDATE catalog SET status = '{status}' WHERE resource_id = $1",
-        RESOURCE_ID
-    )
-    row = await db.fetchrow(
-        "SELECT status FROM catalog WHERE resource_id = $1",
-        RESOURCE_ID
-    )
+    await db.execute(f"UPDATE catalog SET status = '{status}' WHERE resource_id = $1", RESOURCE_ID)
+    row = await db.fetchrow("SELECT status FROM catalog WHERE resource_id = $1", RESOURCE_ID)
     assert row["status"] == status
     await Resource.clean_up_statuses()
-    row = await db.fetchrow(
-        "SELECT status FROM catalog WHERE resource_id = $1",
-        RESOURCE_ID
-    )
+    row = await db.fetchrow("SELECT status FROM catalog WHERE resource_id = $1", RESOURCE_ID)
     if should_reset:
         assert row["status"] is None
     else:

--- a/udata_hydra/cli.py
+++ b/udata_hydra/cli.py
@@ -115,7 +115,7 @@ async def load_catalog(
                     else None,
                 )
         log.info("Resources catalog successfully upserted into DB.")
-        await Resource.clean_up_statuses(conn)
+        await Resource.clean_up_statuses()
         log.info("Stuck statuses sucessfully reset to null.")
     except Exception as e:
         raise e

--- a/udata_hydra/cli.py
+++ b/udata_hydra/cli.py
@@ -115,6 +115,8 @@ async def load_catalog(
                     else None,
                 )
         log.info("Resources catalog successfully upserted into DB.")
+        await Resource.clean_up_statuses()
+        log.info("Stuck statuses sucessfully reset to null.")
     except Exception as e:
         raise e
     finally:

--- a/udata_hydra/cli.py
+++ b/udata_hydra/cli.py
@@ -115,7 +115,7 @@ async def load_catalog(
                     else None,
                 )
         log.info("Resources catalog successfully upserted into DB.")
-        await Resource.clean_up_statuses()
+        await Resource.clean_up_statuses(conn)
         log.info("Stuck statuses sucessfully reset to null.")
     except Exception as e:
         raise e

--- a/udata_hydra/config_default.toml
+++ b/udata_hydra/config_default.toml
@@ -37,6 +37,7 @@ NO_BACKOFF_DOMAINS = [
 BACKOFF_NB_REQ = 180
 BACKOFF_PERIOD = 360    # in seconds
 COOL_OFF_PERIOD = 86400 # 1 day to cool off when we've messed up
+STUCK_THRESHOLD_SECONDS = 3600
 
 # check batch size, beware of open file limits
 # ⚠️ do not exceed MAX_POOL_SIZE

--- a/udata_hydra/crawl/__init__.py
+++ b/udata_hydra/crawl/__init__.py
@@ -5,7 +5,6 @@ from asyncpg import Record
 from udata_hydra import config, context
 from udata_hydra.crawl.check_resources import check_batch_resources
 from udata_hydra.crawl.select_batch import select_batch_resources_to_check
-from udata_hydra.db.resource import Resource
 from udata_hydra.logger import setup_logging
 from udata_hydra.utils import queue  # noqa
 
@@ -26,7 +25,6 @@ async def start_checks(iterations: int = -1) -> None:
         )
 
         while iterations != 0:
-            await Resource.clean_up_statuses()
             batch: list[Record] = await select_batch_resources_to_check()
 
             if batch and len(batch):

--- a/udata_hydra/crawl/__init__.py
+++ b/udata_hydra/crawl/__init__.py
@@ -7,6 +7,7 @@ from udata_hydra.crawl.check_resources import check_batch_resources
 from udata_hydra.crawl.select_batch import select_batch_resources_to_check
 from udata_hydra.logger import setup_logging
 from udata_hydra.utils import queue  # noqa
+from udata_hydra.db.resource import Resource
 
 log = setup_logging()
 
@@ -25,6 +26,7 @@ async def start_checks(iterations: int = -1) -> None:
         )
 
         while iterations != 0:
+            await Resource.clean_up_statuses()
             batch: list[Record] = await select_batch_resources_to_check()
 
             if batch and len(batch):

--- a/udata_hydra/crawl/__init__.py
+++ b/udata_hydra/crawl/__init__.py
@@ -5,9 +5,9 @@ from asyncpg import Record
 from udata_hydra import config, context
 from udata_hydra.crawl.check_resources import check_batch_resources
 from udata_hydra.crawl.select_batch import select_batch_resources_to_check
+from udata_hydra.db.resource import Resource
 from udata_hydra.logger import setup_logging
 from udata_hydra.utils import queue  # noqa
-from udata_hydra.db.resource import Resource
 
 log = setup_logging()
 

--- a/udata_hydra/db/resource.py
+++ b/udata_hydra/db/resource.py
@@ -131,7 +131,7 @@ class Resource:
         )
 
     @staticmethod
-    async def get_stuck_resources() -> list[str]:
+    async def get_stuck_resources(conn) -> list[str]:
         """Some resources end up being stuck in a not null status forever,
         we want to get them back on track.
         This returns all resource ids of such stuck resources.
@@ -144,13 +144,16 @@ class Resource:
             JOIN catalog ca
             ON c.id = ca.last_check
             WHERE ca.status IS NOT NULL AND c.created_at < '{threshold}';"""
-        pool = await context.pool()
-        async with pool.acquire() as connection:
-            rows = await connection.fetch(q)
+        if conn is not None:
+            rows = await conn.fetch(q)
+        else:
+            pool = await context.pool()
+            async with pool.acquire() as connection:
+                rows = await connection.fetch(q)
         return [str(r["resource_id"]) for r in rows] if rows else []
 
     @classmethod
-    async def clean_up_statuses(cls):
-        stuck_resources: list[str] = await cls.get_stuck_resources()
+    async def clean_up_statuses(cls, conn=None):
+        stuck_resources: list[str] = await cls.get_stuck_resources(conn)
         for rid in stuck_resources:
             await cls.update(rid, {"status": None})

--- a/udata_hydra/db/resource.py
+++ b/udata_hydra/db/resource.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, timezone
 from asyncpg import Record
 
 from udata_hydra import config, context
@@ -127,3 +128,28 @@ class Resource:
                 "(catalog.status IS NULL OR catalog.status = 'BACKOFF')",
             ]
         )
+
+    @staticmethod
+    async def get_stuck_resources() -> list[str]:
+        """Some resources end up being stuck in a not null status forever,
+        we want to get them back on track.
+        This returns all resource ids of such stuck resources.
+        """
+        threshold = (
+            datetime.now(timezone.utc) - timedelta(seconds=config.STUCK_THRESHOLD_SECONDS)
+        ).strftime("%Y-%m-%d %H:%M:%S")
+        q = f"""SELECT ca.resource_id
+            FROM checks c
+            JOIN catalog ca
+            ON c.id = ca.last_check
+            WHERE ca.status IS NOT NULL AND c.created_at < '{threshold}';"""
+        pool = await context.pool()
+        async with pool.acquire() as connection:
+            rows = await connection.fetch(q)
+        return [str(r["resource_id"]) for r in rows] if rows else []
+
+    @classmethod
+    async def clean_up_statuses(cls):
+        stuck_resources: list[str] = await cls.get_stuck_resources()
+        for rid in stuck_resources:
+            await cls.update(rid, {"status": None})

--- a/udata_hydra/db/resource.py
+++ b/udata_hydra/db/resource.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+
 from asyncpg import Record
 
 from udata_hydra import config, context


### PR DESCRIPTION
I am wondering if we should also clean statuses that are not within the [current list](https://github.com/datagouv/hydra/blob/df2a916b2c77e595b40d50d2aa53924c580aa3ac/udata_hydra/db/resource.py#L9) in `Resource.clean_up_statuses`