### PR TITLE
Update harvest_modified_at on load catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Update harvest_modified_at on load catalog [#252](https://github.com/datagouv/hydra/pull/252)
 
 ## 2.1.1 (2025-03-12)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -146,7 +146,10 @@ async def test_load_catalog_url_has_changed(setup_catalog, rmock, db, catalog_co
     assert res[0]["url"] == "https://example.com/resource-0"
     assert res[0]["deleted"] is False
 
-async def test_load_catalog_harvest_modified_at_has_changed(setup_catalog, rmock, db, catalog_content):
+
+async def test_load_catalog_harvest_modified_at_has_changed(
+    setup_catalog, rmock, db, catalog_content
+):
     # the harvest_modified_at has changed in comparison to load_catalog
     catalog_content = catalog_content.replace(b'""\n', b'"2025-03-14 15:49:16.876+02"\n')
     catalog = "https://example.com/catalog"
@@ -156,7 +159,9 @@ async def test_load_catalog_harvest_modified_at_has_changed(setup_catalog, rmock
     # check that harvest metadata has been updated
     res = await db.fetch("SELECT * FROM catalog WHERE resource_id = $1", f"{RESOURCE_ID}")
     assert len(res) == 1
-    assert res[0]["harvest_modified_at"] == datetime.fromisoformat("2025-03-14 15:49:16.876+02").replace(tzinfo=timezone.utc)
+    assert res[0]["harvest_modified_at"] == datetime.fromisoformat(
+        "2025-03-14 15:49:16.876+02"
+    ).replace(tzinfo=timezone.utc)
 
 
 async def test_insert_resource_in_catalog(rmock):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -148,7 +148,7 @@ async def test_load_catalog_url_has_changed(setup_catalog, rmock, db, catalog_co
 
 async def test_load_catalog_harvest_modified_at_has_changed(setup_catalog, rmock, db, catalog_content):
     # the harvest_modified_at has changed in comparison to load_catalog
-    catalog_content = catalog_content[:-2] + '"2025-03-14 15:49:16.876+02"'
+    catalog_content = catalog_content[:-2] + b'"2025-03-14 15:49:16.876+02"'
     catalog = "https://example.com/catalog"
     rmock.get(catalog, status=200, body=catalog_content)
     run("load_catalog", url=catalog)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -146,6 +146,18 @@ async def test_load_catalog_url_has_changed(setup_catalog, rmock, db, catalog_co
     assert res[0]["url"] == "https://example.com/resource-0"
     assert res[0]["deleted"] is False
 
+async def test_load_catalog_harvest_modified_at_has_changed(setup_catalog, rmock, db, catalog_content):
+    # the harvest_modified_at has changed in comparison to load_catalog
+    catalog_content = catalog_content[:-2] + '"2025-03-14 15:49:16.876+02"'
+    catalog = "https://example.com/catalog"
+    rmock.get(catalog, status=200, body=catalog_content)
+    run("load_catalog", url=catalog)
+
+    # check that harvest metadata has been updated
+    res = await db.fetch("SELECT * FROM catalog WHERE resource_id = $1", f"{RESOURCE_ID}")
+    assert len(res) == 1
+    assert res[0]["harvest_modified_at"] == "2025-03-14 15:49:16.876+02"
+
 
 async def test_insert_resource_in_catalog(rmock):
     new_dataset_id = "a" * 24

--- a/udata_hydra/cli.py
+++ b/udata_hydra/cli.py
@@ -104,7 +104,8 @@ async def load_catalog(
                     ON CONFLICT (resource_id) DO UPDATE SET
                         dataset_id = $1,
                         url = $3,
-                        deleted = FALSE;
+                        deleted = FALSE,
+                        harvest_modified_at = $4;
                 """,
                     row["dataset.id"],
                     row["id"],


### PR DESCRIPTION
For example, [this resource](https://www.data.gouv.fr/fr/datasets/liste-des-experiences-partagees-par-les-usagers/#/resources/91ea5a74-35f9-48d3-86cb-4407bf766927) stills has `analysis:last-modified-detection : harvest-resource-metadata` even though the dataset is not harvested anymore.