### PR TITLE
Update code for resources_exceptions table migration

### DIFF
--- a/udata_hydra/db/resource_exception.py
+++ b/udata_hydra/db/resource_exception.py
@@ -16,7 +16,7 @@ class ResourceException:
         """
         Get all resource_exceptions
         """
-        pool = await context.pool()
+        pool = await context.pool("csv")
         async with pool.acquire() as connection:
             q = "SELECT * FROM resources_exceptions;"
             return await connection.fetch(q)
@@ -26,7 +26,7 @@ class ResourceException:
         """
         Get a resource_exception by its resource_id
         """
-        pool = await context.pool()
+        pool = await context.pool("csv")
         async with pool.acquire() as connection:
             q = "SELECT * FROM resources_exceptions WHERE resource_id = $1;"
             return await connection.fetchrow(q, resource_id)
@@ -43,7 +43,7 @@ class ResourceException:
         table_indexes is a JSON object of column names and index types
         e.g. {"siren": "unique", "code_postal": "index"}
         """
-        pool = await context.pool()
+        pool = await context.pool("csv")
 
         # First, check if the resource_id exists in the catalog table
         resource: dict | None = await Resource.get(resource_id)
@@ -77,7 +77,7 @@ class ResourceException:
         table_indexes is a JSON object of column names and index types
         e.g. {"siren": "unique", "code_postal": "index"}
         """
-        pool = await context.pool()
+        pool = await context.pool("csv")
 
         # First, check if the resource_id exists in the catalog table
         resource: dict | None = await Resource.get(resource_id)
@@ -105,7 +105,7 @@ class ResourceException:
         """
         Delete a resource_exception by its resource_id
         """
-        pool = await context.pool()
+        pool = await context.pool("csv")
         async with pool.acquire() as connection:
             q = "DELETE FROM resources_exceptions WHERE resource_id = $1;"
             await connection.execute(q, resource_id)


### PR DESCRIPTION
⚠️ this should be merged when the table is manually moved from the `main` db to the `csv` db (for `postgrest` access of indexes for `tabular-api`)