### PR TITLE
Try using tippecanoe python lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Make sure detected_last_modified_at is set even if HAS_NOT_CHANGED [#257](https://github.com/datagouv/hydra/pull/257)
 - Fill in new check even if no update [#258](https://github.com/datagouv/hydra/pull/258)
 - Better change detections and add related tests [#259](https://github.com/datagouv/hydra/pull/259)
-- Enable GeoJSON to PMTiles conversion [#260](https://github.com/datagouv/hydra/pull/260)
+- Enable GeoJSON to PMTiles conversion [#260](https://github.com/datagouv/hydra/pull/260) [#267](https://github.com/datagouv/hydra/pull/267)
 - Parquet files are named after resource ids [#262](https://github.com/datagouv/hydra/pull/262)
 - Upgrade csv-detective [#263](https://github.com/datagouv/hydra/pull/263)
 

--- a/udata_hydra/analysis/geojson.py
+++ b/udata_hydra/analysis/geojson.py
@@ -114,7 +114,6 @@ async def geojson_to_pmtiles(
     output_pmtiles = f"{resource_id}.pmtiles"
 
     command = [
-        "tippecanoe",
         "--maximum-zoom=g",  # guess
         "-o",
         output_pmtiles,
@@ -122,7 +121,9 @@ async def geojson_to_pmtiles(
         "--extend-zooms-if-still-dropping",
         file_path,
     ]
-    tippecanoe._program("tippecanoe", *command)
+    code = tippecanoe._program("tippecanoe", *command)
+    if code:
+        raise ValueError(f"GeoJSON to PMTiles conversion failed for {file_path}")
     log.debug(f"Successfully converted {file_path} to {output_pmtiles}")
 
     pmtiles_size = os.path.getsize(output_pmtiles)

--- a/udata_hydra/analysis/geojson.py
+++ b/udata_hydra/analysis/geojson.py
@@ -4,6 +4,7 @@ import subprocess
 from datetime import datetime, timezone
 
 from asyncpg import Record
+import tippecanoe
 
 from udata_hydra import config
 from udata_hydra.analysis import helpers
@@ -121,7 +122,7 @@ async def geojson_to_pmtiles(
         "--extend-zooms-if-still-dropping",
         file_path,
     ]
-    subprocess.run(command, check=True)
+    tippecanoe._program("tippecanoe", *command)
     log.debug(f"Successfully converted {file_path} to {output_pmtiles}")
 
     pmtiles_size = os.path.getsize(output_pmtiles)

--- a/udata_hydra/analysis/geojson.py
+++ b/udata_hydra/analysis/geojson.py
@@ -121,8 +121,8 @@ async def geojson_to_pmtiles(
         "--extend-zooms-if-still-dropping",
         file_path,
     ]
-    code = tippecanoe._program("tippecanoe", *command)
-    if code:
+    exit_code = tippecanoe._program("tippecanoe", *command)
+    if exit_code:
         raise ValueError(f"GeoJSON to PMTiles conversion failed for {file_path}")
     log.debug(f"Successfully converted {file_path} to {output_pmtiles}")
 

--- a/udata_hydra/analysis/geojson.py
+++ b/udata_hydra/analysis/geojson.py
@@ -3,8 +3,8 @@ import os
 import subprocess
 from datetime import datetime, timezone
 
-from asyncpg import Record
 import tippecanoe
+from asyncpg import Record
 
 from udata_hydra import config
 from udata_hydra.analysis import helpers


### PR DESCRIPTION
Instead of using subprocess, we use tippecanoe python lib, that should use correct bin path for tippecanoe

See the content of `/lib/python3.11/site-packages/tippecanoe/__init__.py`