### PR TITLE
Select DISTINCT parsing table in purge_selected_csv_tables CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fix some CLI functions to improve local debug [#269](https://github.com/datagouv/hydra/pull/269)
 - Upgrade csv-detective and use previous analysis to validate if available [#266](https://github.com/datagouv/hydra/pull/266)
-- Fix and add new purge tables CLI utils [#271](https://github.com/datagouv/hydra/pull/271) [#272](https://github.com/datagouv/hydra/pull/272)
+- Fix and add new purge tables CLI utils [#271](https://github.com/datagouv/hydra/pull/271) [#272](https://github.com/datagouv/hydra/pull/272) [#273](https://github.com/datagouv/hydra/pull/273)
 
 ## 2.2.0 (2025-05-16)
 

--- a/udata_hydra/cli.py
+++ b/udata_hydra/cli.py
@@ -463,7 +463,7 @@ async def purge_selected_csv_tables(
         q = """SELECT DISTINCT parsing_table FROM tables_index WHERE created_at <= $1"""
         res: list[Record] = await conn_csv.fetch(q, threshold)
     elif retention_tables is not None:
-        q = """SELECT DISTINCT parsing_table FROM tables_index ORDER BY created_at DESC OFFSET $1"""
+        q = """SELECT DISTINCT ON (created_at) parsing_table FROM tables_index ORDER BY created_at DESC OFFSET $1"""
         res: list[Record] = await conn_csv.fetch(q, int(retention_tables))
 
     tables_to_delete: list[str] = [r["parsing_table"] for r in res]

--- a/udata_hydra/cli.py
+++ b/udata_hydra/cli.py
@@ -460,10 +460,10 @@ async def purge_selected_csv_tables(
     conn_csv = await connection(db_name="csv")
     if retention_days is not None:
         threshold = datetime.now(timezone.utc) - timedelta(days=int(retention_days))
-        q = """SELECT parsing_table FROM tables_index WHERE created_at <= $1"""
+        q = """SELECT DISTINCT parsing_table FROM tables_index WHERE created_at <= $1"""
         res: list[Record] = await conn_csv.fetch(q, threshold)
     elif retention_tables is not None:
-        q = """SELECT parsing_table FROM tables_index ORDER BY created_at DESC OFFSET $1"""
+        q = """SELECT DISTINCT parsing_table FROM tables_index ORDER BY created_at DESC OFFSET $1"""
         res: list[Record] = await conn_csv.fetch(q, int(retention_tables))
 
     tables_to_delete: list[str] = [r["parsing_table"] for r in res]


### PR DESCRIPTION
Without this, we end up trying to delete the same parsing_table mutliple times.
It doesn't fail, but it wastes useless time deleting already deleted contents