### PR TITLE
Add parsing_table in extra analysis payload

### DIFF
--- a/tests/test_analysis/test_analysis_csv.py
+++ b/tests/test_analysis/test_analysis_csv.py
@@ -306,9 +306,10 @@ async def test_analyse_csv_send_udata_webhook(
     webhook = rmock.requests[("PUT", URL(udata_url))][0].kwargs["json"]
     assert webhook.get("analysis:parsing:started_at")
     assert webhook.get("analysis:parsing:finished_at")
+    assert webhook.get("analysis:parsing:parsing_table")
     assert webhook.get("analysis:parsing:error") is None
     for k in ["parquet_size", "parquet_url"]:
-        assert webhook.get("analysis:parsing:error", False) is None
+        assert webhook.get(f"analysis:parsing:{k}", False) is None
 
 
 @pytest.mark.parametrize(
@@ -373,6 +374,7 @@ async def test_forced_analysis(
         webhook = rmock.requests[("PUT", URL(udata_url))][0].kwargs["json"]
         assert webhook.get("analysis:parsing:started_at")
         assert webhook.get("analysis:parsing:finished_at")
+        assert webhook.get("analysis:parsing:parsing_table")
         assert webhook.get("analysis:parsing:error") is None
         for k in ["parquet_size", "parquet_url"]:
             assert webhook.get("analysis:parsing:error", False) is None

--- a/udata_hydra/analysis/helpers.py
+++ b/udata_hydra/analysis/helpers.py
@@ -67,6 +67,8 @@ async def notify_udata(resource: Record, check: dict) -> None:
             else None,
         },
     }
+    if config.CSV_TO_DB and check.get("parsing_table"):
+        payload["document"]["analysis:parsing:parsing_table"] = check.get("parsing_table")
     if config.CSV_TO_PARQUET and check.get("parquet_url"):
         payload["document"]["analysis:parsing:parquet_url"] = check.get("parquet_url")
         payload["document"]["analysis:parsing:parquet_size"] = check.get("parquet_size")

--- a/udata_hydra/utils/http.py
+++ b/udata_hydra/utils/http.py
@@ -27,6 +27,7 @@ class UdataPayload:
             "error",
             "started_at",
             "finished_at",
+            "parsing_table",
             "parquet_size",
             "parquet_url",
             "pmtiles_size",


### PR DESCRIPTION
It is useful for cdata to know specifically which are available between geojson, pmtiles & DB table.

We should probably migrate existing extras to add the `parsing_table` extras on the stock.