### PR TITLE
ci: Update PostgreSQL version in CI to match Docker Compose (15.13)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
   tests:
     docker:
       - image: cimg/python:<< pipeline.parameters.python-version >>
-      - image: cimg/postgres:11.15
+      - image: cimg/postgres:15.13
         environment:
           POSTGRES_DB: postgres
           POSTGRES_USER: postgres

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add parsing_table in extra analysis payload [#279](https://github.com/datagouv/hydra/pull/279)
 - Add a column in catalog that indicates when the status was last changed and delete the status-specific endpoint [#276](https://github.com/datagouv/hydra/pull/276)
 - Remove F401 (unused import) ignore rule and clean up __init__.py files with explicit __all__ declarations [#281](https://github.com/datagouv/hydra/pull/281)
+- Update PostgreSQL version in CI to match Docker Compose (15.13) [#282](https://github.com/datagouv/hydra/pull/282)
 
 ## 2.2.1 (2025-06-11)
 


### PR DESCRIPTION
This PR fixes a PostgreSQL version mismatch between CI and local development environments.

Problem
CI environment: Used PostgreSQL 11.15 (cimg/postgres:11.15)
Local development: Uses PostgreSQL 15 (postgres:15 in docker-compose.yml)
This version mismatch could cause inconsistent test behavior and potential issues in production

Solution
Updated the CircleCI configuration to use PostgreSQL 15.13 (cimg/postgres:15.13) to match the Docker Compose setup.