### PR TITLE
clean: consistent return types for CRUD methods

### DIFF
--- a/udata_hydra/db/check.py
+++ b/udata_hydra/db/check.py
@@ -69,7 +69,7 @@ class Check:
             return await connection.fetchrow(q, url or resource_id)
 
     @classmethod
-    async def get_all(cls, url: str | None = None, resource_id: str | None = None) -> list | None:
+    async def get_all(cls, url: str | None = None, resource_id: str | None = None) -> list[Record]:
         column: str = "url" if url else "resource_id"
         pool = await context.pool()
         async with pool.acquire() as connection:
@@ -84,7 +84,9 @@ class Check:
             return await connection.fetch(q, url or resource_id)
 
     @classmethod
-    async def get_group_by_for_date(cls, column: str, date: date, page_size: int = 20):
+    async def get_group_by_for_date(
+        cls, column: str, date: date, page_size: int = 20
+    ) -> list[Record]:
         pool = await context.pool()
         async with pool.acquire() as connection:
             q = f"""

--- a/udata_hydra/db/resource.py
+++ b/udata_hydra/db/resource.py
@@ -40,7 +40,7 @@ class Resource:
         format: str,
         status: str | None = None,
         priority: bool = True,
-    ) -> None:
+    ) -> Record | None:
         if status and status not in cls.STATUSES.keys():
             raise ValueError(f"Invalid status: {status}")
 
@@ -59,12 +59,12 @@ class Resource:
                         status = $6,
                         priority = $7
                     RETURNING *;"""
-            await connection.fetchrow(
+            return await connection.fetchrow(
                 q, dataset_id, resource_id, url, type, format, status, priority
             )
 
     @classmethod
-    async def update(cls, resource_id: str, data: dict) -> Record:
+    async def update(cls, resource_id: str, data: dict) -> Record | None:
         """Update a resource in DB with new data and return the updated resource in DB"""
         if "status" in data:
             data["status_since"] = datetime.now(timezone.utc)
@@ -91,7 +91,7 @@ class Resource:
         format: str,
         status: str | None = None,
         priority: bool = True,  # Make resource high priority by default for crawling
-    ) -> None:
+    ) -> Record | None:
         if status and status not in cls.STATUSES.keys():
             raise ValueError(f"Invalid status: {status}")
 
@@ -117,7 +117,7 @@ class Resource:
                             status = $6,
                             priority = $7
                         RETURNING *;"""
-            await connection.fetchrow(
+            return await connection.fetchrow(
                 q, dataset_id, resource_id, url, type, format, status, priority
             )
 

--- a/udata_hydra/db/resource_exception.py
+++ b/udata_hydra/db/resource_exception.py
@@ -37,7 +37,7 @@ class ResourceException:
         resource_id: str,
         table_indexes: dict[str, str] | None = None,
         comment: str | None = None,
-    ) -> Record:
+    ) -> Record | None:
         """
         Insert a new resource_exception
         table_indexes is a JSON object of column names and index types
@@ -46,7 +46,7 @@ class ResourceException:
         pool = await context.pool("csv")
 
         # First, check if the resource_id exists in the catalog table
-        resource: dict | None = await Resource.get(resource_id)
+        resource: Record | None = await Resource.get(resource_id)
         if not resource:
             raise ValueError("Resource not found")
 
@@ -71,7 +71,7 @@ class ResourceException:
         resource_id: str,
         table_indexes: dict[str, str] | None = None,
         comment: str | None = None,
-    ) -> Record:
+    ) -> Record | None:
         """
         Update a resource_exception
         table_indexes is a JSON object of column names and index types
@@ -80,7 +80,7 @@ class ResourceException:
         pool = await context.pool("csv")
 
         # First, check if the resource_id exists in the catalog table
-        resource: dict | None = await Resource.get(resource_id)
+        resource: Record | None = await Resource.get(resource_id)
         if not resource:
             raise ValueError("Resource not found")
 

--- a/udata_hydra/utils/db.py
+++ b/udata_hydra/utils/db.py
@@ -3,7 +3,7 @@ from asyncpg import Record
 from udata_hydra import context
 
 
-async def get_columns_with_indexes(table_name: str) -> list[Record] | None:
+async def get_columns_with_indexes(table_name: str) -> list[Record]:
     """
     Get the columns of a table which have indexes
     Return a list of records with the following columns:


### PR DESCRIPTION
### Fix type hints for CRUD methods

This PR fixes type annotation inconsistencies in database CRUD methods:
- `Check.update()`: Now properly handles Record | None return type from `update_table_record()`
- `ResourceException.insert()` and `update()`: Fixed `dict()` conversion of `Record | None` from `Resource.get()`
- `csv_to_db_index()`: Updated parameter type from Record to dict to match usage
- `handle_parse_exception()`: Updated parameter type from `dict | None` to `Record | None` to match usage
- These changes ensure type safety when working with database records and eliminate linter errors related to incompatible type assignments between Record and dict types.