### PR TITLE
fix: optimize queue priorities for resource processing 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Upgrade dependencies and fix pytest-asyncio deprecated code [#305](https://github.com/datagouv/hydra/pull/305)
 - Handle new cases of geo columns from csv-detective [#303](https://github.com/datagouv/hydra/pull/303)
 - Fix custom Sentry error by capturing original exception stack trace and add test [#308](https://github.com/datagouv/hydra/pull/308)
+- Optimize queue priorities for resource processing [#311](https://github.com/datagouv/hydra/pull/311)
 
 ## 2.3.0 (2025-07-15)
 

--- a/tests/test_crawl/test_crawl.py
+++ b/tests/test_crawl/test_crawl.py
@@ -723,12 +723,17 @@ async def test_reset_statuses(fake_check, db, setup_catalog, check_duration):
     [
         (
             "udata_hydra.crawl.check_resources.check_resource",
-            {"url": ANY, "resource": ANY, "session": ANY, "worker_priority": "high"},
+            {"url": ANY, "resource": ANY, "session": ANY, "worker_priority": "default"},
             "ok",
         ),
         (
             "udata_hydra.analysis.resource.analyse_resource",
-            {"check": ANY, "last_check": ANY, "force_analysis": False, "worker_priority": "high"},
+            {
+                "check": ANY,
+                "last_check": ANY,
+                "force_analysis": False,
+                "worker_priority": "default",
+            },
             None,
         ),
     ],

--- a/udata_hydra/crawl/check_resources.py
+++ b/udata_hydra/crawl/check_resources.py
@@ -44,7 +44,7 @@ async def check_batch_resources(to_parse: list[Record]) -> None:
                     url=row["url"],
                     resource=row,
                     session=session,
-                    worker_priority="high" if row["priority"] else "low",
+                    worker_priority="default" if row["priority"] else "low",
                 )
             )
         for task in asyncio.as_completed(tasks):


### PR DESCRIPTION
Closes https://github.com/datagouv/hydra/issues/310
Related discussion: https://mattermost.incubateur.net/betagouv/pl/1qt9fgsjw7yo3y8ii7u6y4xdmh

Reduces congestion in high-priority queue while maintaining udata synchronization as a priority.

**Priority resources in DB** (`priority=True`): Crawl and analysis use "default" priority  
**Non-priority resources in DB** (`priority=False`): Crawl and analysis use "low" priority  
**Udata notifications**: Always "high" priority (no change)