### PR TITLE
refactor: split `csv_to_geojson_and_pmtiles()` into intermediary function `csv_to_geojon()` for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Optimize queue priorities for resource processing [#311](https://github.com/datagouv/hydra/pull/311)
 - Add `resource_id` info in timer logs and add timer for analysing resource [#313](https://github.com/datagouv/hydra/pull/313)
 - Add check id in udata extras to facilitate debug [#307](https://github.com/datagouv/hydra/pull/307)
-- Split `csv_to geojson_and_pmtiles()` function into a new intermediary function `csv_to_geojson()` for better unit testing/benchmarking [#317](https://github.com/datagouv/hydra/pull/317)
+- Split `csv_to geojson_and_pmtiles` function into a new intermediary function `csv_to_geojson` for better unit testing/benchmarking [#317](https://github.com/datagouv/hydra/pull/317)
 
 ## 2.3.0 (2025-07-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Optimize queue priorities for resource processing [#311](https://github.com/datagouv/hydra/pull/311)
 - Add `resource_id` info in timer logs and add timer for analysing resource [#313](https://github.com/datagouv/hydra/pull/313)
 - Add check id in udata extras to facilitate debug [#307](https://github.com/datagouv/hydra/pull/307)
+- Split `csv_to geojson_and_pmtiles()` function into a new intermediary function `csv_to_geojson()` for better unit testing/benchmarking [#317](https://github.com/datagouv/hydra/pull/317)
 
 ## 2.3.0 (2025-07-15)
 

--- a/udata_hydra/analysis/geojson.py
+++ b/udata_hydra/analysis/geojson.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pandas as pd
 import tippecanoe
@@ -65,7 +66,7 @@ async def analyse_geojson(
         # Convert to PMTiles
         try:
             pmtiles_url, pmtiles_size = await geojson_to_pmtiles(
-                file_path=tmp_file.name,
+                file_path=Path(tmp_file.name),
                 resource_id=resource_id,
             )
             timer.mark("geojson-to-pmtiles")
@@ -250,7 +251,7 @@ async def csv_to_geojson(
 
 
 async def geojson_to_pmtiles(
-    file_path: str,
+    file_path: Path,
     resource_id: str | None = None,
 ) -> tuple[str, int]:
     """
@@ -278,7 +279,7 @@ async def geojson_to_pmtiles(
         output_pmtiles,
         "--coalesce-densest-as-needed",
         "--extend-zooms-if-still-dropping",
-        file_path,
+        str(file_path),
     ]
     exit_code = tippecanoe._program("tippecanoe", *command)
     if exit_code:
@@ -311,7 +312,7 @@ async def csv_to_geojson_and_pmtiles(
         return None
 
     geojson_url, geojson_size = result
-    geojson_file = f"{resource_id}.geojson"
+    geojson_file = Path(f"{resource_id}.geojson")
 
     await Check.update(
         check_id,
@@ -331,7 +332,7 @@ async def csv_to_geojson_and_pmtiles(
         },
     )
 
-    os.remove(geojson_file)
+    geojson_file.unlink()
 
     # returning only for tests purposes
     return geojson_url, geojson_size, pmtiles_url, pmtiles_size

--- a/udata_hydra/analysis/geojson.py
+++ b/udata_hydra/analysis/geojson.py
@@ -304,7 +304,8 @@ async def csv_to_geojson_and_pmtiles(
     inspection: dict,
     resource_id: str | None = None,
     check_id: int | None = None,
-) -> tuple[str, int, str | None, int] | None:
+    cleanup: bool = True,
+) -> tuple[Path, int, str | None, Path, int, str | None] | None:
     if not config.CSV_TO_GEOJSON:
         log.debug("CSV_TO_GEOJSON turned off, skipping geojson/PMtiles export.")
         return None
@@ -340,8 +341,9 @@ async def csv_to_geojson_and_pmtiles(
         },
     )
 
-    geojson_filepath.unlink()
-    pmtiles_filepath.unlink()
+    if cleanup:
+        geojson_filepath.unlink()
+        pmtiles_filepath.unlink()
 
     # returning only for tests purposes
-    return geojson_url, geojson_size, pmtiles_url, pmtiles_size
+    return geojson_filepath, geojson_size, geojson_url, pmtiles_filepath, pmtiles_size, pmtiles_url

--- a/udata_hydra/analysis/geojson.py
+++ b/udata_hydra/analysis/geojson.py
@@ -178,7 +178,7 @@ async def csv_to_geojson(
                 {
                     "type": "Feature",
                     # json is not pre-cast by csv-detective
-                    "geometry": json.loads(str(row[geo["geometry"]])),
+                    "geometry": json.loads(row[geo["geometry"]]),
                     "properties": {
                         col: prevent_nan(row[col]) for col in df.columns if col != geo["geometry"]
                     },
@@ -194,7 +194,7 @@ async def csv_to_geojson(
                     "type": "Feature",
                     "geometry": {
                         "type": "Point",
-                        "coordinates": cast_latlon(str(row[geo["latlon"]])),
+                        "coordinates": cast_latlon(row[geo["latlon"]]),
                     },
                     "properties": {
                         col: prevent_nan(row[col]) for col in df.columns if col != geo["latlon"]
@@ -212,7 +212,7 @@ async def csv_to_geojson(
                     "geometry": {
                         "type": "Point",
                         # inverting lon and lat to match the standard
-                        "coordinates": cast_latlon(str(row[geo["lonlat"]]))[::-1],
+                        "coordinates": cast_latlon(row[geo["lonlat"]])[::-1],
                     },
                     "properties": {
                         col: prevent_nan(row[col]) for col in df.columns if col != geo["lonlat"]

--- a/udata_hydra/analysis/geojson.py
+++ b/udata_hydra/analysis/geojson.py
@@ -138,7 +138,7 @@ async def csv_to_geojson(
             return None
         return value
 
-    log.debug(f"Converting to geojson for {resource_id} and sending to Minio.")
+    log.debug(f"Converting to geojson for {resource_id}")
 
     geo = {}
     for column, detection in inspection["columns"].items():
@@ -244,6 +244,7 @@ async def csv_to_geojson(
     geojson_size: int = os.path.getsize(geojson_filepath)
 
     if upload_to_minio:
+        log.debug(f"Sending GeoJSON file {geojson_filepath} to MinIO")
         geojson_url = minio_client_geojson.send_file(str(geojson_filepath), delete_source=False)
     else:
         geojson_url = None
@@ -292,6 +293,7 @@ async def geojson_to_pmtiles(
     pmtiles_size: int = os.path.getsize(pmtiles_filepath)
 
     if upload_to_minio:
+        log.debug(f"Sending PMTiles file {pmtiles_filepath} to MinIO")
         pmtiles_url = minio_client_pmtiles.send_file(str(pmtiles_filepath), delete_source=False)
     else:
         pmtiles_url = None
@@ -311,7 +313,7 @@ async def csv_to_geojson_and_pmtiles(
         return None
 
     log.debug(
-        f"Converting to geojson and PMtiles if relevant for {resource_id} and sending to Minio."
+        f"Converting to geojson and PMtiles if relevant for {resource_id} and sending to MinIO."
     )
 
     # Convert CSV to GeoJSON


### PR DESCRIPTION
Partly helps https://github.com/datagouv/data.gouv.fr/issues/1847:

- Split `csv_to geojson_and_pmtiles()` function into a new intermediary function `csv_to_geojon()`, in order to better unit test and benchmark the csv to PMtiles workflow later ; so that functions `csv_to_geojon()` and `geojson_to_pmtiles()` can now be called by the tests or from the CLI independently with new, consistent arguments and return types for testing.

Also, on the way:

- Use of `pathlib.Path` instead of strings for file paths whenever possible in `csv_to geojson_and_pmtiles()`, `csv_to_geojon()` and `geojson_to_pmtiles()`, for safer, cleaner, and more readable file operations.

- Adapt tests to cleanup the test data files through a `cleanup` function argument instead of a mock on `os`.

The branch `benchmark` will be rebased on this PR, so measure performance of each step independently.