### PR TITLE
fix: fix deprecated Sentry method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Split `csv_to geojson_and_pmtiles` function into a new intermediary function `csv_to_geojson` for better unit testing/benchmarking [#317](https://github.com/datagouv/hydra/pull/317)
 - Add download resource CLI command [#320](https://github.com/datagouv/hydra/pull/320)
 - Fix custom exception `ExceptionWithSentryDetails` to include Python stack trace [#315](https://github.com/datagouv/hydra/pull/315)
+- Fix deprecated Sentry method [#323](https://github.com/datagouv/hydra/pull/323)
 
 ## 2.3.0 (2025-07-15)
 

--- a/udata_hydra/logger.py
+++ b/udata_hydra/logger.py
@@ -40,5 +40,6 @@ def setup_logging() -> logging.Logger:
 
 def stop_sentry() -> None:
     """Stop sentry collection programatically"""
-    if sentry_sdk.Hub.current.client:
-        sentry_sdk.Hub.current.client.close()
+    client = sentry_sdk.get_client()
+    if client:
+        client.close()


### PR DESCRIPTION
We were using the deprecated `sentry_sdk.Hub.current` API in the `stop_sentry()` function in `logger.py`.

Warning message:
_SentryHubDeprecationWarning: `sentry_sdk.Hub` is deprecated and will be removed in a future major release. Please consult our 1.x to 2.x migration guide for details on how to migrate `Hub` usage to the new API_

According to [the Sentry 1.x to 2.x migration guide](https://docs.sentry.io/platforms/python/migration/1.x-to-2.x), the Hub-based APIs are deprecated and should be replaced with the new scope-based approach.

