### PR TITLE
Return updated check in `handle_resource_exception` to send the right payload to udata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Upgrade csv-detective [#322](https://github.com/datagouv/hydra/pull/322) [#324](https://github.com/datagouv/hydra/pull/324) [#327](https://github.com/datagouv/hydra/pull/327)
 - Stream geojson conversion to prevent RAM consumption [#326](https://github.com/datagouv/hydra/pull/326)
 - Gracefully crash if any of the column names is too long for Postgres [#329](https://github.com/datagouv/hydra/pull/329)
+- Retrieve check before sending to udata in case of changes [#330](https://github.com/datagouv/hydra/pull/330)
 
 ## 2.3.0 (2025-07-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Upgrade csv-detective [#322](https://github.com/datagouv/hydra/pull/322) [#324](https://github.com/datagouv/hydra/pull/324) [#327](https://github.com/datagouv/hydra/pull/327)
 - Stream geojson conversion to prevent RAM consumption [#326](https://github.com/datagouv/hydra/pull/326)
 - Gracefully crash if any of the column names is too long for Postgres [#329](https://github.com/datagouv/hydra/pull/329)
-- Retrieve check before sending to udata in case of changes [#330](https://github.com/datagouv/hydra/pull/330)
+- Return updated check in `handle_resource_exception` to send the right payload to udata [#330](https://github.com/datagouv/hydra/pull/330)
 
 ## 2.3.0 (2025-07-15)
 

--- a/udata_hydra/analysis/csv.py
+++ b/udata_hydra/analysis/csv.py
@@ -206,6 +206,8 @@ async def analyse_csv(
     except (ParseException, IOException) as e:
         await handle_parse_exception(e, table_name, check)
     finally:
+        # re-getting the check data as it may have been modified since last retrieval
+        check = await Check.get_by_id(check["id"])
         await helpers.notify_udata(resource, check)
         timer.stop()
         if tmp_file is not None:

--- a/udata_hydra/analysis/csv.py
+++ b/udata_hydra/analysis/csv.py
@@ -204,10 +204,8 @@ async def analyse_csv(
         await csv_to_db_index(table_name, csv_inspection, check)
 
     except (ParseException, IOException) as e:
-        await handle_parse_exception(e, table_name, check)
+        check = await handle_parse_exception(e, table_name, check)
     finally:
-        # re-getting the check data as it may have been modified since last retrieval
-        check = await Check.get_by_id(check["id"])
         await helpers.notify_udata(resource, check)
         timer.stop()
         if tmp_file is not None:

--- a/udata_hydra/analysis/geojson.py
+++ b/udata_hydra/analysis/geojson.py
@@ -91,10 +91,8 @@ async def analyse_geojson(
         )
 
     except (ParseException, IOException) as e:
-        await handle_parse_exception(e, None, check)
+        check = await handle_parse_exception(e, None, check)
     finally:
-        # re-getting the check data as it may have been modified since last retrieval
-        check = await Check.get_by_id(check["id"])
         await helpers.notify_udata(resource, check)
         timer.stop()
         if tmp_file is not None:

--- a/udata_hydra/analysis/geojson.py
+++ b/udata_hydra/analysis/geojson.py
@@ -93,6 +93,8 @@ async def analyse_geojson(
     except (ParseException, IOException) as e:
         await handle_parse_exception(e, None, check)
     finally:
+        # re-getting the check data as it may have been modified since last retrieval
+        check = await Check.get_by_id(check["id"])
         await helpers.notify_udata(resource, check)
         timer.stop()
         if tmp_file is not None:


### PR DESCRIPTION
In `await handle_parse_exception(e, table_name, check)` we update the check in db but we don't refetch the content, therefore sending an incomplete check payload to udata in `await helpers.notify_udata(resource, check)`