### PR TITLE
fix: fix user agent string

### DIFF
--- a/udata_hydra/__init__.py
+++ b/udata_hydra/__init__.py
@@ -1,6 +1,7 @@
 import importlib.metadata
 import logging
 import os
+import re
 import tomllib
 from pathlib import Path
 
@@ -53,7 +54,13 @@ class Configurator:
     def USER_AGENT_FULL(self) -> str:
         """Build the complete user agent string with version"""
         if self.USER_AGENT and self.APP_VERSION:
-            return f"{self.USER_AGENT}/{self.APP_VERSION}"
+            # Use regex to find pattern: / followed by version-like string
+            pattern = r"/([^/\s]+)(?=\s|$)"
+            result = re.sub(pattern, f"/{self.APP_VERSION}", self.USER_AGENT)
+            # If no replacement was made (no version found), append it
+            if result == self.USER_AGENT:
+                return f"{self.USER_AGENT}/{self.APP_VERSION}"
+            return result
         return "udata-hydra"
 
 

--- a/udata_hydra/config_default.toml
+++ b/udata_hydra/config_default.toml
@@ -13,7 +13,7 @@ SENTRY_SAMPLE_RATE = 1.0
 TESTING = false
 # max postgres pool size
 MAX_POOL_SIZE = 50
-USER_AGENT = "udata-hydra" # without version - version is dynamically added
+USER_AGENT = "udata-hydra/X.X data.gouv.fr crawler <abuse@data.gouv.fr>" # without version - version is dynamically added
 NAMEDATALEN = 64  # should be set to the same value as in Postgres, but we can't query it
 
 API_KEY = "hydra_api_key_to_change"


### PR DESCRIPTION
Fix the dynamic building of USER_AGENT_FULL since on the production setting we use USER_AGENT setting like "`udata-hydra/1.0 data.gouv.fr crawler <abuse@data.gouv.fr>`", and not "`udata-hydra`" or "`udata-hydra/1.0`" like in the default config.

We now use a regex so that it would work in all those cases:
- `udata-hydra/1.0 data.gouv.fr crawler <abuse@data.gouv.fr>` -> `udata-hydra/<APP_VERSION> data.gouv.fr crawler <abuse@data.gouv.fr>`
- `udata-hydra/X.X data.gouv.fr crawler <abuse@data.gouv.fr>` -> `udata-hydra/<APP_VERSION> data.gouv.fr crawler <abuse@data.gouv.fr>`
- `udata-hydra/1.0` -> `udata-hydra/<APP_VERSION>`
- `udata-hydra` -> `udata-hydra/<APP_VERSION>`
etc.