### PR TITLE
Enable to analyse and insert parquet files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Allow crawling of non datagouv URLs with CLI [#312](https://github.com/datagouv/hydra/pull/312)
 - Flag deleted resources in CSV DB instead of deleting them [#340](https://github.com/datagouv/hydra/pull/340)
 - Add a CI workflow for performance benchmarks [#339](https://github.com/datagouv/hydra/pull/339)
+- Enable to analyse and insert parquet files [#342](https://github.com/datagouv/hydra/pull/342)
 
 ## 2.4.1 (2025-09-03)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -259,8 +259,9 @@ async def fake_check():
         geojson_url=False,
         url=None,
     ) -> dict:
+        _url = url or f"https://example.com/resource-{resource}"
         data = {
-            "url": url or f"https://example.com/resource-{resource}",
+            "url": _url,
             "domain": domain,
             "status": status,
             "headers": json.dumps(headers),
@@ -274,7 +275,7 @@ async def fake_check():
             "analysis_error": analysis_error,
             "detected_last_modified_at": detected_last_modified_at,
             "next_check_at": next_check_at,
-            "parsing_table": hashlib.md5(url.encode("utf-8")).hexdigest()
+            "parsing_table": hashlib.md5(_url.encode("utf-8")).hexdigest()
             if parsing_table
             else None,
             "parquet_url": "https://example.org/file.parquet" if parquet_url else None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -257,10 +257,10 @@ async def fake_check():
         domain="example.com",
         pmtiles_url=False,
         geojson_url=False,
+        url=None,
     ) -> dict:
-        url = f"https://example.com/resource-{resource}"
         data = {
-            "url": url,
+            "url": url or f"https://example.com/resource-{resource}",
             "domain": domain,
             "status": status,
             "headers": json.dumps(headers),

--- a/tests/test_analysis/test_analysis_parquet.py
+++ b/tests/test_analysis/test_analysis_parquet.py
@@ -1,0 +1,105 @@
+import hashlib
+from datetime import datetime
+import json
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from udata_hydra.analysis.parquet import analyse_parquet
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.mark.asyncio
+async def test_analyse_parquet_disabled(fake_check):
+    """Test that the function returns None when PARQUET_TO_DB is False (by default)"""
+    with patch("udata_hydra.analysis.helpers.read_or_download_file") as mock_func:
+        check = await fake_check()
+        result = await analyse_parquet(check, "test.parquet")
+        assert result is None
+        mock_func.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "check_kwargs",
+    [
+        {"url": "http://example.com/file.parquet"},
+        {"headers": {"content-type": "application/vnd.apache.parquet"}}
+    ]
+)
+async def test_analyse_parquet(
+    setup_catalog, rmock, db, fake_check, produce_mock, check_kwargs,
+):
+    check = await fake_check(**check_kwargs)
+    url = check["url"]
+    table_name = hashlib.md5(url.encode("utf-8")).hexdigest()
+    parquet_file_content = pd.DataFrame(
+        {
+            "name": ["Marie", "Paul", "Léa", "Pierre"],
+            "score": [1.2, 3.4, 5.6, 7.8],
+            "decompte": [98, -76, -5, 0],
+            "is_true": [True, False, False, True],
+            "birth": [
+                datetime.strptime("1996-02-13", "%Y-%m-%d"),
+                datetime.strptime("2000-01-28", "%Y-%m-%d"),
+                datetime.strptime("2005-11-10", "%Y-%m-%d"),
+                datetime.strptime("2018-01-31", "%Y-%m-%d"),
+            ],
+            "stamp": [
+                datetime.fromisoformat("2018-07-01T01:53:26.972000+00:00"),
+                datetime.fromisoformat("2020-10-07T11:53:26.972000+00:00"),
+                datetime.fromisoformat("1998-01-31T21:53:26.972000-04:00"),
+                datetime.fromisoformat("2022-12-31T11:33:26.972000+02:00"),
+            ],
+            "liste": [
+                [1, 2],
+                [-3, 2],
+                [6, -2],
+                [-18, -17],
+            ],
+            "dicts": [
+                {"a": 1},
+                {"b": 2},
+                {"c": 3},
+                {"d": 4, "e": 5},
+            ],
+        }
+    ).to_parquet()
+    expected_types = {
+        "name": {"python": "string", "pg": "character varying"},
+        "score": {"python": "float", "pg": "double precision"},
+        "decompte": {"python": "int", "pg": "bigint"},
+        "is_true": {"python": "bool", "pg": "boolean"},
+        "birth": {"python": "datetime", "pg": "timestamp without time zone"},
+        "stamp": {"python": "datetime_aware", "pg": "timestamp with time zone"},
+        "liste": {"python": "json", "pg": "json"},
+        "dicts": {"python": "json", "pg": "json"},
+    }
+    rmock.get(url, status=200, body=parquet_file_content)
+    with patch("udata_hydra.config.PARQUET_TO_DB", True):
+        await analyse_parquet(check=check)
+
+    # checking check result
+    res = await db.fetchrow("SELECT * FROM checks")
+    assert res["parsing_table"] == table_name
+    assert res["parsing_error"] is None
+
+    # checking table content
+    rows = list(await db.fetch(f'SELECT * FROM "{table_name}"'))
+    assert len(rows) == 4
+    pgtypes = await db.fetchrow(
+        "SELECT "
+        + ", ".join([f"pg_typeof({col}) as {col}" for col in expected_types.keys()])
+        + f' FROM "{table_name}"'
+    )
+
+    # checking analysis
+    res = await db.fetchrow(
+        "SELECT csv_detective FROM tables_index WHERE resource_id = $1", check["resource_id"]
+    )
+    inspection = json.loads(res["csv_detective"])
+
+    for col, types in expected_types.items():
+        assert pgtypes[col] == types["pg"]
+        assert inspection["columns"][col]["python_type"] == types["python"]

--- a/tests/test_analysis/test_analysis_parquet.py
+++ b/tests/test_analysis/test_analysis_parquet.py
@@ -1,6 +1,6 @@
 import hashlib
-from datetime import datetime
 import json
+from datetime import datetime
 from unittest.mock import patch
 
 import pandas as pd
@@ -25,11 +25,16 @@ async def test_analyse_parquet_disabled(fake_check):
     "check_kwargs",
     [
         {"url": "http://example.com/file.parquet"},
-        {"headers": {"content-type": "application/vnd.apache.parquet"}}
-    ]
+        {"headers": {"content-type": "application/vnd.apache.parquet"}},
+    ],
 )
 async def test_analyse_parquet(
-    setup_catalog, rmock, db, fake_check, produce_mock, check_kwargs,
+    setup_catalog,
+    rmock,
+    db,
+    fake_check,
+    produce_mock,
+    check_kwargs,
 ):
     check = await fake_check(**check_kwargs)
     url = check["url"]

--- a/tests/test_analysis/test_analysis_parquet.py
+++ b/tests/test_analysis/test_analysis_parquet.py
@@ -11,16 +11,6 @@ from udata_hydra.analysis.parquet import analyse_parquet
 pytestmark = pytest.mark.asyncio
 
 
-@pytest.mark.asyncio
-async def test_analyse_parquet_disabled(fake_check):
-    """Test that the function returns None when PARQUET_TO_DB is False (by default)"""
-    with patch("udata_hydra.analysis.helpers.read_or_download_file") as mock_func:
-        check = await fake_check()
-        result = await analyse_parquet(check, "test.parquet")
-        assert result is None
-        mock_func.assert_not_called()
-
-
 @pytest.mark.parametrize(
     "check_kwargs",
     [

--- a/udata_hydra/analysis/parquet.py
+++ b/udata_hydra/analysis/parquet.py
@@ -2,15 +2,14 @@ import hashlib
 import json
 import logging
 import os
-from datetime import datetime, timezone
 import re
+from datetime import datetime, timezone
 from typing import Iterator
 
 import numpy as np
 import pandas as pd
 import pyarrow.parquet as pq
 from asyncpg import Record
-
 from progressist import ProgressBar
 
 from udata_hydra import config, context

--- a/udata_hydra/analysis/parquet.py
+++ b/udata_hydra/analysis/parquet.py
@@ -59,6 +59,8 @@ async def analyse_parquet(
 
     resource_id: str = str(check["resource_id"])
     url = check["url"]
+    # Preserve dataset_id from original check record
+    dataset_id = check.get("dataset_id")
 
     resource: Record | None = await Resource.update(resource_id, {"status": "ANALYSING_PARQUET"})
 
@@ -140,7 +142,7 @@ async def analyse_parquet(
                 "parsing_finished_at": datetime.now(timezone.utc),
             },
         )
-        await parquet_to_db_index(table_name, inspection, check)
+        await parquet_to_db_index(table_name, inspection, check, dataset_id)
 
     except (ParseException, IOException) as e:
         check = await handle_parse_exception(e, table_name, check)
@@ -259,6 +261,11 @@ async def parquet_to_db(
             await db.execute(q, *data.values())
 
 
-async def parquet_to_db_index(table_name: str, inspection: dict, check: Record) -> None:
+async def parquet_to_db_index(
+    table_name: str,
+    inspection: dict,
+    check: Record,
+    dataset_id: str,
+) -> None:
     # convenience method just to make it clearer
-    await csv_to_db_index(table_name, inspection, check)
+    await csv_to_db_index(table_name, inspection, check, dataset_id)

--- a/udata_hydra/analysis/parquet.py
+++ b/udata_hydra/analysis/parquet.py
@@ -1,0 +1,254 @@
+import hashlib
+import json
+import logging
+import os
+from datetime import datetime, timezone
+import re
+from typing import Iterator
+
+import pandas as pd
+import pyarrow.parquet as pq
+from asyncpg import Record
+
+from progressist import ProgressBar
+
+from udata_hydra import config, context
+from udata_hydra.analysis import helpers
+from udata_hydra.analysis.csv import compute_create_table_query, csv_to_db_index
+from udata_hydra.db import compute_insert_query
+from udata_hydra.db.check import Check
+from udata_hydra.db.resource import Resource
+from udata_hydra.db.resource_exception import ResourceException
+from udata_hydra.utils import (
+    IOException,
+    ParseException,
+    Timer,
+    handle_parse_exception,
+)
+
+log = logging.getLogger("udata-hydra")
+
+PYARROW_TYPE_TO_PYTHON = {
+    # using regex because of bits-differing types (e.g. int32 and int64)
+    # the "^" makes sure we don't consider the types of elements within structured objects (lists, dicts)
+    "string$": "string",  # large_string also exists
+    "^double": "float",
+    "^float": "float",
+    "^decimal": "float",
+    "^int": "int",
+    "^bool": "bool",
+    "^date": "date",
+    "^struct": "json",  # dictionary
+    "^list": "json",
+    r"^timestamp\[\ws\]": "datetime_naive",
+    r"^timestamp\[\ws,": "datetime_aware",  # the rest of the field depends on the timezone
+}
+
+RESERVED_COLS = ("__id", "cmin", "cmax", "collation", "ctid", "tableoid", "xmin", "xmax")
+
+
+async def analyse_parquet(
+    check: dict,
+    file_path: str | None = None,
+    debug_insert: bool = False,
+) -> None:
+    """Insert parquet file and metadata in db"""
+    if not config.PARQUET_TO_DB:
+        log.debug("PARQUET_TO_DB turned off, skipping.")
+        return
+
+    resource_id: str = str(check["resource_id"])
+    url = check["url"]
+
+    resource: Record | None = await Resource.update(resource_id, {"status": "ANALYSING_PARQUET"})
+
+    # Check if the resource is in the exceptions table
+    # If it is, get the table_indexes to use them later
+    exception: Record | None = await ResourceException.get_by_resource_id(resource_id)
+    table_indexes: dict | None = None
+    if exception and exception.get("table_indexes"):
+        table_indexes = json.loads(exception["table_indexes"])
+
+    timer = Timer("analyse-parquet", resource_id)
+    assert any(_ is not None for _ in (check["id"], url))
+
+    table_name, tmp_file = None, None
+    try:
+        tmp_file = await helpers.read_or_download_file(
+            check=check,
+            file_path=file_path,
+            file_format="parquet",
+            exception=exception,
+        )
+        table_name = hashlib.md5(url.encode("utf-8")).hexdigest()
+        timer.mark("download-file")
+
+        check = await Check.update(check["id"], {"parsing_started_at": datetime.now(timezone.utc)})
+
+        # open the file and read the metadata
+        try:
+            parquet_file = pq.ParquetFile(tmp_file.name)
+            columns = {}
+            for col in parquet_file.schema_arrow:
+                col_type = str(col.type)
+                if col_type.startswith("dictionary"):
+                    # dictionaries are for columns with repeated values
+                    # we need to dig deeper to get the type
+                    col_type = str(col.type.value_type)
+                try:
+                    columns[col.name] = next(
+                        pytype
+                        for pyartype, pytype in PYARROW_TYPE_TO_PYTHON.items()
+                        if re.match(pyartype, col_type)
+                    )
+                except StopIteration:
+                    raise ValueError(f"Unknown pyarrow type: {col.type}")
+            inspection = {
+                "columns": {
+                    col_name: {
+                        "format": pytype,
+                        "python_type": pytype,
+                    }
+                    for col_name, pytype in columns.items()
+                }
+            }
+            inspection["total_lines"] = parquet_file.metadata.num_rows
+        except Exception as e:
+            raise ParseException(
+                message=str(e),
+                step="parquet_analysis",
+                resource_id=resource_id,
+                url=url,
+                check_id=check["id"],
+            ) from e
+        timer.mark("parquet-analysis")
+
+        await parquet_to_db(
+            parquet_file=parquet_file,
+            inspection=inspection,
+            table_name=table_name,
+            table_indexes=table_indexes,
+            resource_id=resource_id,
+            debug_insert=debug_insert,
+        )
+        check = await Check.update(check["id"], {"parsing_table": table_name})
+        timer.mark("parquet-to-db")
+
+        check = await Check.update(
+            check["id"],
+            {
+                "parsing_finished_at": datetime.now(timezone.utc),
+            },
+        )
+        await parquet_to_db_index(table_name, inspection, check)
+
+    except (ParseException, IOException) as e:
+        check = await handle_parse_exception(e, table_name, check)
+    finally:
+        await helpers.notify_udata(resource, check)
+        timer.stop()
+        if tmp_file is not None:
+            tmp_file.close()
+            os.remove(tmp_file.name)
+
+        # Reset resource status to None
+        await Resource.update(resource_id, {"status": None})
+
+
+def generate_records_from_parquet(parquet_file: pq.ParquetFile) -> Iterator[list]:
+    # pandas cannot have None in columns typed as int so we have to cast
+    # NaN-int values to None for db insertion, and we also change NaN to None
+    for batch in parquet_file.iter_batches():
+        df = batch.to_pandas()
+        for row in df.values:
+            yield tuple(cell if not pd.isna(cell) else None for cell in row)
+
+
+async def parquet_to_db(
+    parquet_file: pq.ParquetFile,
+    inspection: dict,
+    table_name: str,
+    table_indexes: dict[str, str] | None = None,
+    resource_id: str | None = None,
+    debug_insert: bool = False,
+) -> None:
+    """
+    Convert a parquet file to database table using inspection data. It should (re)create one table:
+    - `table_name` with data from `file_path`
+
+    :parquet_file: parquet file to convert
+    :inspection: CSV detective-like report
+    :table_name: used to create tables
+    :debug_insert: insert record one by one instead of using postgresql COPY
+    """
+
+    log.debug(f"Converting from parquet to db for {table_name}")
+
+    if any(
+        sum(len(char.encode("utf-8")) for char in col) > config.NAMEDATALEN - 1
+        for col in inspection["columns"]
+    ):
+        raise ParseException(
+            step="scan_column_names",
+            resource_id=resource_id,
+            table_name=table_name,
+        ) from ValueError(
+            f"Column names cannot exceed {config.NAMEDATALEN - 1} characters in Postgres"
+        )
+
+    if resource_id:
+        # Update resource status to INSERTING_IN_DB
+        await Resource.update(resource_id, {"status": "INSERTING_IN_DB"})
+
+    # build a `column_name: type` mapping and explicitely rename reserved column names
+    columns = {
+        f"{c}__hydra_renamed" if c.lower() in RESERVED_COLS else c: helpers.get_python_type(v)
+        for c, v in inspection["columns"].items()
+    }
+
+    q = f'DROP TABLE IF EXISTS "{table_name}"'
+    db = await context.pool("csv")
+    await db.execute(q)
+
+    # Create table
+    q = compute_create_table_query(table_name=table_name, columns=columns, indexes=table_indexes)
+    try:
+        await db.execute(q)
+    except Exception as e:
+        raise ParseException(
+            message=str(e),
+            step="create_table_query",
+            resource_id=resource_id,
+            table_name=table_name,
+        ) from e
+
+    # this use postgresql COPY from an iterator, it's fast but might be difficult to debug
+    if not debug_insert:
+        # NB: also see copy_to_table for a file source
+        try:
+            await db.copy_records_to_table(
+                table_name,
+                records=generate_records_from_parquet(parquet_file),
+                columns=list(columns.keys()),
+            )
+        except Exception as e:  # I know what I'm doing, pinky swear
+            raise ParseException(
+                message=str(e),
+                step="copy_records_to_table",
+                resource_id=resource_id,
+                table_name=table_name,
+            ) from e
+    # this inserts rows from iterator one by one, slow but useful for debugging
+    else:
+        bar = ProgressBar(total=inspection["total_lines"])
+        for r in bar.iter(generate_records_from_parquet(parquet_file)):
+            data = {k: v for k, v in zip(parquet_file.schema.names, r)}
+            print(data)
+            # NB: possible sql injection here, but should not be used in prod
+            q = compute_insert_query(table_name=table_name, data=data, returning="__id")
+            await db.execute(q, *data.values())
+
+
+async def parquet_to_db_index(table_name: str, inspection: dict, check: Record) -> None:
+    # convenience method just to make it clearer
+    await csv_to_db_index(table_name, inspection, check)

--- a/udata_hydra/analysis/resource.py
+++ b/udata_hydra/analysis/resource.py
@@ -86,16 +86,12 @@ async def analyse_resource(
             row: Record = await connection.fetchrow(
                 "SELECT format FROM catalog WHERE resource_id = $1", f"{check['resource_id']}"
             )
-        is_geojson: bool = (
-            row["format"] == "geojson"
-            or await detect_geojson_from_headers(check)
-        )
+        is_geojson: bool = row["format"] == "geojson" or await detect_geojson_from_headers(check)
         if is_geojson:
             file_format = "geojson"
         if not is_geojson:
-            is_parquet: bool = (
-                row["format"] == "parquet"
-                or await detect_parquet_from_headers(check)
+            is_parquet: bool = row["format"] == "parquet" or await detect_parquet_from_headers(
+                check
             )
             if is_parquet:
                 file_format = "parquet"

--- a/udata_hydra/cli.py
+++ b/udata_hydra/cli.py
@@ -17,6 +17,7 @@ from progressist import ProgressBar
 from udata_hydra import config
 from udata_hydra.analysis.csv import analyse_csv, csv_detective_routine
 from udata_hydra.analysis.geojson import analyse_geojson, csv_to_geojson, geojson_to_pmtiles
+from udata_hydra.analysis.parquet import analyse_parquet
 from udata_hydra.analysis.resource import analyse_resource
 from udata_hydra.crawl.check_resources import check_resource as crawl_check_resource
 from udata_hydra.db.check import Check
@@ -414,6 +415,37 @@ async def convert_geojson_to_pmtiles_cli(geojson_filepath: str):
         import traceback
 
         traceback.print_exc()
+
+
+@cli(name="analyse-parquet")
+async def analyse_parquet_cli(
+    check_id: str | None = None,
+    url: str | None = None,
+    resource_id: str | None = None,
+):
+    """Trigger a parquet analysis from a check_id, an url or a resource_id
+    Try to get the check from the check ID, then from the URL
+    """
+    assert check_id or url or resource_id
+    check = None
+    if check_id:
+        check: Record | None = await Check.get_by_id(int(check_id), with_deleted=True)
+    if not check and url:
+        checks: list[Record] | None = await Check.get_by_url(url)
+        if checks and len(checks) > 1:
+            log.warning(f"Multiple checks found for URL {url}, using the latest one")
+        check = checks[0] if checks else None
+    if not check and resource_id:
+        check: Record | None = await Check.get_by_resource_id(resource_id)
+    if not check:
+        if check_id:
+            log.error("Could not retrieve the specified check")
+        elif url:
+            log.error("Could not find a check linked to the specified URL")
+        elif resource_id:
+            log.error("Could not find a check linked to the specified resource ID")
+        return
+    await analyse_parquet(check=dict(check))
 
 
 @cli

--- a/udata_hydra/config_default.toml
+++ b/udata_hydra/config_default.toml
@@ -57,6 +57,7 @@ MAX_FILESIZE_ALLOWED.xls = 52428800    # /2
 MAX_FILESIZE_ALLOWED.xlsx = 13107200   # /8
 MAX_FILESIZE_ALLOWED.ods = 10485760    # /10
 MAX_FILESIZE_ALLOWED.geojson = 104857600
+MAX_FILESIZE_ALLOWED.parquet = 52428800
 
 # -- CSV analysis settings -- #
 SQL_INDEXES_TYPES_SUPPORTED = ["index"]
@@ -93,3 +94,6 @@ MINIO_PMTILES_FOLDER = "" # no trailing slash
 CSV_TO_GEOJSON = false
 MINIO_GEOJSON_BUCKET = ""
 MINIO_GEOJSON_FOLDER = "" # no trailing slash
+
+# -- Parquet analysis settings -- #
+PARQUET_TO_DB = false

--- a/udata_hydra/db/resource.py
+++ b/udata_hydra/db/resource.py
@@ -25,6 +25,8 @@ class Resource:
         "ANALYSING_GEOJSON": "geojson resource content currently being analysed",
         "CONVERTING_TO_PMTILES": "currently being converted to pmtiles",
         "CONVERTING_TO_GEOJSON": "csv is currently being converted to geojson",
+        "TO_ANALYSE_PARQUET": "parquet resource content to be analysed",
+        "ANALYSING_PARQUET": "retrieving parquet column metadata",
     }
 
     @classmethod

--- a/udata_hydra/utils/__init__.py
+++ b/udata_hydra/utils/__init__.py
@@ -8,8 +8,9 @@ from .file import (
     extract_gzip,
     remove_remainders,
 )
-from .geojson import detect_geojson_from_headers_or_catalog
+from .geojson import detect_geojson_from_headers
 from .http import UdataPayload, get_request_params, send
+from .parquet import detect_parquet_from_headers
 from .queue import enqueue
 from .timer import Timer
 
@@ -24,10 +25,11 @@ __all__ = [
     "download_resource",
     "extract_gzip",
     "remove_remainders",
-    "detect_geojson_from_headers_or_catalog",
+    "detect_geojson_from_headers",
     "UdataPayload",
     "get_request_params",
     "send",
+    "detect_parquet_from_headers",
     "enqueue",
     "Timer",
 ]

--- a/udata_hydra/utils/geojson.py
+++ b/udata_hydra/utils/geojson.py
@@ -1,24 +1,13 @@
 import json
 
-from asyncpg import Record
 
-from udata_hydra import context
-
-
-async def detect_geojson_from_headers_or_catalog(check: dict) -> bool:
+async def detect_geojson_from_headers(check: dict) -> bool:
     headers: dict = json.loads(check["headers"] or "{}")
     # in some cases geojson files have the content-type `application/json`
     # but adding this in the list would not have been a restrictive enough condition
-    # so we check the URL, and also the format in the catalog
+    # so we check the URL
     # (still not good enough for static resources ending with .json only)
-    if any(
+    return any(
         headers.get("content-type", "").lower().startswith(ct)
         for ct in ["application/vnd.geo+json"]
-    ) or "geojson" in check.get("url", ""):
-        return True
-    pool = await context.pool()
-    async with pool.acquire() as connection:
-        row: Record = await connection.fetchrow(
-            "SELECT format FROM catalog WHERE resource_id = $1", f"{check['resource_id']}"
-        )
-    return row["format"] == "geojson"
+    ) or "geojson" in check.get("url", "")

--- a/udata_hydra/utils/parquet.py
+++ b/udata_hydra/utils/parquet.py
@@ -1,5 +1,5 @@
-from io import BytesIO
 import json
+from io import BytesIO
 
 import pandas as pd
 

--- a/udata_hydra/utils/parquet.py
+++ b/udata_hydra/utils/parquet.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+import json
 
 import pandas as pd
 
@@ -12,3 +13,14 @@ def save_as_parquet(
         compression="zstd",  # best compression to date
     )
     return f"{output_filename}.parquet", bytes
+
+
+async def detect_parquet_from_headers(check: dict) -> bool:
+    headers: dict = json.loads(check["headers"] or "{}")
+    # most parquet files are exposed with "application/octet-stream"
+    # which combined with "parquet" in the url is a good hint
+    # the ideal case is "application/vnd.apache.parquet"
+    return any(
+        headers.get("content-type", "").lower().startswith(ct)
+        for ct in ["application/vnd.apache.parquet"]
+    ) or "parquet" in check.get("url", "")


### PR DESCRIPTION
So that they have a preview ✨ I am not sure what a good size limit would be, as parquet file are quite extensive, maybe 50Mo? We still have the exception mechanism anyway

Insight: the refactoring of `udata_hydra/analysis/resource.py` is to get the resource's format from the catalog only once