### PR TITLE
feat: better logs for CLI commands run by crons

### DIFF
--- a/udata_hydra/cli.py
+++ b/udata_hydra/cli.py
@@ -55,6 +55,8 @@ async def load_catalog(
     :drop_all: drop metadata tables and parsed csv content
     :quiet: ingore logs except for errors
     """
+    start_time = datetime.now(timezone.utc)
+    original_level = log.level
     if quiet:
         log.setLevel(logging.ERROR)
 
@@ -118,6 +120,15 @@ async def load_catalog(
         log.info("Resources catalog successfully upserted into DB.")
         await Resource.clean_up_statuses()
         log.info("Stuck statuses sucessfully reset to null.")
+        end_time = datetime.now(timezone.utc)
+        log.setLevel(logging.INFO)
+        log.info(
+            f"load_catalog completed. Start time: {start_time.isoformat()}, End time: {end_time.isoformat()}\n"
+        )
+        if quiet:
+            log.setLevel(logging.ERROR)
+        else:
+            log.setLevel(original_level)
     except Exception as e:
         raise e
     finally:
@@ -543,6 +554,8 @@ async def migrate(skip_errors: bool = False, dbs: list[str] = ["main", "csv"]):
 @cli
 async def purge_checks(retention_days: int = 60, quiet: bool = False) -> None:
     """Delete outdated checks that are more than `retention_days` days old"""
+    start_time = datetime.now(timezone.utc)
+    original_level = log.level
     if quiet:
         log.setLevel(logging.ERROR)
 
@@ -552,7 +565,16 @@ async def purge_checks(retention_days: int = 60, quiet: bool = False) -> None:
         f"""WITH deleted AS (DELETE FROM checks WHERE created_at < now() - interval '{retention_days} days' RETURNING *) SELECT count(*) FROM deleted"""
     )
     deleted: int = res["count"]
+    end_time = datetime.now(timezone.utc)
     log.info(f"Deleted {deleted} checks.")
+    log.setLevel(logging.INFO)
+    log.info(
+        f"purge_checks completed. Start time: {start_time.isoformat()}, End time: {end_time.isoformat()}\n"
+    )
+    if quiet:
+        log.setLevel(logging.ERROR)
+    else:
+        log.setLevel(original_level)
 
 
 @cli
@@ -563,6 +585,8 @@ async def purge_csv_tables(quiet: bool = False, hard_delete: bool = False) -> No
 
     # Fetch all parsing tables from checks where we don't have any entry on
     # md5(url) in catalog or all entries are marked as deleted.
+    start_time = datetime.now(timezone.utc)
+    original_level = log.level
     if quiet:
         log.setLevel(logging.ERROR)
 
@@ -615,6 +639,15 @@ async def purge_csv_tables(quiet: bool = False, hard_delete: bool = False) -> No
         log.warning(f"Failed to delete {error_count} table(s). Check logs for details.")
     if not (success_count or error_count):
         log.info("Nothing to delete.")
+    end_time = datetime.now(timezone.utc)
+    log.setLevel(logging.INFO)
+    log.info(
+        f"purge_csv_tables completed. Start time: {start_time.isoformat()}, End time: {end_time.isoformat()}\n"
+    )
+    if quiet:
+        log.setLevel(logging.ERROR)
+    else:
+        log.setLevel(original_level)
 
 
 @cli


### PR DESCRIPTION
## Add execution time logging for CLI commands used in cron jobs

Adds start and end time logging for `load_catalog`, `purge_checks`, and `purge_csv_tables` to improve monitoring of cron job execution.
- Log execution start and end times (UTC, ISO format) for the three commands
- Ensure these logs are always displayed, even in quiet mode (by temporarily restoring INFO level)

The timing logs follow this format:
```
load_catalog completed. Start time: 2025-01-XX..., End time: 2025-01-XX...
```
