### PR TITLE
Revert "feat: better logs for CLI commands run by crons (#354)"

### DIFF
--- a/udata_hydra/cli.py
+++ b/udata_hydra/cli.py
@@ -55,8 +55,6 @@ async def load_catalog(
     :drop_all: drop metadata tables and parsed csv content
     :quiet: ingore logs except for errors
     """
-    start_time = datetime.now(timezone.utc)
-    original_level = log.level
     if quiet:
         log.setLevel(logging.ERROR)
 
@@ -120,15 +118,6 @@ async def load_catalog(
         log.info("Resources catalog successfully upserted into DB.")
         await Resource.clean_up_statuses()
         log.info("Stuck statuses sucessfully reset to null.")
-        end_time = datetime.now(timezone.utc)
-        log.setLevel(logging.INFO)
-        log.info(
-            f"load_catalog completed. Start time: {start_time.isoformat()}, End time: {end_time.isoformat()}\n"
-        )
-        if quiet:
-            log.setLevel(logging.ERROR)
-        else:
-            log.setLevel(original_level)
     except Exception as e:
         raise e
     finally:
@@ -554,8 +543,6 @@ async def migrate(skip_errors: bool = False, dbs: list[str] = ["main", "csv"]):
 @cli
 async def purge_checks(retention_days: int = 60, quiet: bool = False) -> None:
     """Delete outdated checks that are more than `retention_days` days old"""
-    start_time = datetime.now(timezone.utc)
-    original_level = log.level
     if quiet:
         log.setLevel(logging.ERROR)
 
@@ -565,16 +552,7 @@ async def purge_checks(retention_days: int = 60, quiet: bool = False) -> None:
         f"""WITH deleted AS (DELETE FROM checks WHERE created_at < now() - interval '{retention_days} days' RETURNING *) SELECT count(*) FROM deleted"""
     )
     deleted: int = res["count"]
-    end_time = datetime.now(timezone.utc)
     log.info(f"Deleted {deleted} checks.")
-    log.setLevel(logging.INFO)
-    log.info(
-        f"purge_checks completed. Start time: {start_time.isoformat()}, End time: {end_time.isoformat()}\n"
-    )
-    if quiet:
-        log.setLevel(logging.ERROR)
-    else:
-        log.setLevel(original_level)
 
 
 @cli
@@ -585,8 +563,6 @@ async def purge_csv_tables(quiet: bool = False, hard_delete: bool = False) -> No
 
     # Fetch all parsing tables from checks where we don't have any entry on
     # md5(url) in catalog or all entries are marked as deleted.
-    start_time = datetime.now(timezone.utc)
-    original_level = log.level
     if quiet:
         log.setLevel(logging.ERROR)
 
@@ -639,15 +615,6 @@ async def purge_csv_tables(quiet: bool = False, hard_delete: bool = False) -> No
         log.warning(f"Failed to delete {error_count} table(s). Check logs for details.")
     if not (success_count or error_count):
         log.info("Nothing to delete.")
-    end_time = datetime.now(timezone.utc)
-    log.setLevel(logging.INFO)
-    log.info(
-        f"purge_csv_tables completed. Start time: {start_time.isoformat()}, End time: {end_time.isoformat()}\n"
-    )
-    if quiet:
-        log.setLevel(logging.ERROR)
-    else:
-        log.setLevel(original_level)
 
 
 @cli


### PR DESCRIPTION
This reverts commit ac4a74064388235c4a5d869526819539a382ac92.

Je suis obligé de revert [ma PR d'hier sur les logs améliorés des crons d'Hydra](https://github.com/datagouv/hydra/pull/354) après discussion avec @jordanguedj  car l'infra envoie des mails concernant les crons pour chaque output dans les logs files. On ne peut rien y mettre sinon ça bombarde de mails... Faire autrement serait assez compliqué (EDIT: j'ai pas mal regardé hier on pourrait faire des regex dans des task Ansible pour détecter si l'output n'a qu'une ligne par exemple, mais ça me paraît extremement lourdeau et peu maintenable, pas vrai @jordanguedj ?)
