### PR TITLE
chore: remove parallel tests executors and add minimum test coverage of 80%

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,6 @@ jobs:
           POSTGRES_DB: postgres
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-    parallelism: 4 # Number of executed tests in parallel
     steps:
       - attach_workspace:
           at: .
@@ -100,18 +99,7 @@ jobs:
             DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
             UDATA_INSTANCE_NAME: udata
           command: |
-            # Find and split tests
-            TESTFILES=$(find tests -name "test_*.py" | circleci tests split --split-by=timings)
-            # Debug: Show what's in TESTFILES
-            echo "Test files assigned to the executor ${CIRCLE_NODE_INDEX}/${CIRCLE_NODE_TOTAL}:"
-            echo "$TESTFILES"
-            # Run the found tests
-            if [ -n "$TESTFILES" ]; then
-              uv run pytest --junitxml=reports/python/tests.xml -p no:sugar --color=yes $TESTFILES
-            else
-              echo "No tests to run in this split"
-              exit 1
-            fi
+            uv run pytest --junitxml=reports/python/tests.xml -p no:sugar --color=yes tests/
       - store_test_results:
           path: reports/python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,8 +73,7 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "catalog_harvested: use catalog_harvested.csv as source",
 ]
-# addopts = "--cov=udata_hydra/ --cov-report term-missing --cov-fail-under=89" # if we want to fail if coverage is less than 89%
-# addopts = "--cov=udata_hydra/ --cov-report term-missing"
+addopts = "--cov=udata_hydra --cov-report term-missing --cov-branch --cov-fail-under=80"
 
 [tool.ruff]
 lint = { extend-select = ["I"] } # ["I"] is to also sort imports with an isort rule


### PR DESCRIPTION
Coverage was lower in CI than locally because of the CI configuration wasn't collecting or combining coverage across parallel executors — so coverage was failing on the first executor, which had only run about 60% of the total tests.

Three possible solutions:
1. 	Drop the minimum coverage requirement in CI
2. 	Disable parallel test execution in CI, which currently saves roughly 2 minutes (from about 4m30 down to 3m30): **[this PR](https://github.com/datagouv/hydra/pull/356)**
3. 	Add an extra job in CI to combine coverage reports from the three executors — but that adds around ten seconds and makes the CI more complex. PR: https://github.com/datagouv/hydra/pull/347

This PR also includes:
- Added --cov-branch to enables branch coverage, which measures whether both branches of conditionals are tested
- Enforces a 80% threshold (not 89% since we added --cov-branch)
