### PR TITLE
feat: add parsing_table index on checks

### DIFF
--- a/udata_hydra/migrations/main/20251103_add_parsing_table_index_on_checks.sql
+++ b/udata_hydra/migrations/main/20251103_add_parsing_table_index_on_checks.sql
@@ -1,0 +1,2 @@
+-- add parsing_table index on checks table, to improve performance when querying depending on parsing_table
+CREATE INDEX IF NOT EXISTS parsing_table_idx ON checks (parsing_table);


### PR DESCRIPTION
Current `purge_csv_tables` job takes too long and this should help