### PR TITLE
fix: resolve async/await compatibility issues with Typer CLI

### DIFF
--- a/udata_hydra/cli.py
+++ b/udata_hydra/cli.py
@@ -989,12 +989,6 @@ def purge_selected_csv_tables(
     )
 
 
-async def cleanup():
-    """Cleanup function to close database connections"""
-    for db in context["conn"]:
-        await context["conn"][db].close()
-
-
 def run():
     """Main entry point for the CLI"""
     cli()


### PR DESCRIPTION
This PR fixes CLI commands that were broken after migrating from minicli to Typer, which doesn't handle async functions directly. 

All async CLI commands are now wrapped with synchronous functions that use `_make_async_wrapper()` to detect the execution context and run async code appropriately. The wrapper automatically detects if an event loop is already running (for tests) or creates one using `asyncio.run()` (for CLI execution), ensuring compatibility with both direct CLI usage and async test environments.

The unused `cleanup()` function has been removed, and redundant exception handling (`except Exception as e: raise e`) has been cleaned up. All CLI commands now work correctly without RuntimeWarnings about unawaited coroutines.

...

...but it's VERY ugly and verbose.