### PR TITLE
feat: optimize cleanup of stuck status resources

### DIFF
--- a/udata_hydra/cli.py
+++ b/udata_hydra/cli.py
@@ -130,8 +130,8 @@ async def _load_catalog(
                     else None,
                 )
         log.info("Resources catalog successfully upserted into DB.")
-        await Resource.clean_up_statuses()
-        log.info("Stuck statuses sucessfully reset to null.")
+        cleaned_count: int = await Resource.clean_up_statuses()
+        log.info(f" {cleaned_count} stuck statuses successfully reset to null.")
     except Exception as e:
         raise e
     finally:

--- a/udata_hydra/db/resource.py
+++ b/udata_hydra/db/resource.py
@@ -159,26 +159,23 @@ class Resource:
         )
 
     @staticmethod
-    async def get_stuck_resources() -> list[str]:
-        """Some resources end up being stuck in a not null status forever,
-        we want to get them back on track.
-        This returns all resource ids of such stuck resources.
-        """
-        threshold = (
-            datetime.now(timezone.utc) - timedelta(seconds=config.STUCK_THRESHOLD_SECONDS)
-        ).strftime("%Y-%m-%d %H:%M:%S")
-        q = f"""SELECT ca.resource_id
-            FROM checks c
-            JOIN catalog ca
-            ON c.id = ca.last_check
-            WHERE ca.status IS NOT NULL AND c.created_at < '{threshold}';"""
+    async def clean_up_statuses() -> int:
+        """Some resources end up being stuck in a not null status forever, we want to get them back on track.
+        This returns the number of such stuck resources that were cleaned up."""
+        threshold = datetime.now(timezone.utc) - timedelta(seconds=config.STUCK_THRESHOLD_SECONDS)
+
         pool = await context.pool()
         async with pool.acquire() as connection:
-            rows = await connection.fetch(q)
-        return [str(r["resource_id"]) for r in rows] if rows else []
-
-    @classmethod
-    async def clean_up_statuses(cls):
-        stuck_resources: list[str] = await cls.get_stuck_resources()
-        for rid in stuck_resources:
-            await cls.update(rid, {"status": None})
+            # Update all stuck resources in a single query
+            q = """
+                UPDATE catalog
+                SET status = NULL, status_since = $1
+                WHERE resource_id IN (
+                    SELECT ca.resource_id
+                    FROM checks c
+                    JOIN catalog ca ON c.id = ca.last_check
+                    WHERE ca.status IS NOT NULL AND c.created_at < $2
+                )
+            """
+            result = await connection.execute(q, datetime.now(timezone.utc), threshold)
+            return result  # Returns the number of affected rows


### PR DESCRIPTION
Replaces the iterative cleanup approach with a single SQL UPDATE query that processes all stuck resources at once, improving performance in `load_catalog`.

**Performance improvement:**
- Before: 1 SELECT query + N UPDATE queries (one per stuck resource)
- After: 1 single UPDATE query with subquery
- Reduces database round-trips and allows PostgreSQL to optimize the operation atomically