### PR TITLE
refactor: refactor docker-compose files to use profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Converted CSV tables will be stored in the database specified via `config.DATABA
 
 ## 🧪 Tests
 
-To run the tests, you need to launch the database, the test database, and the Redis broker with `docker compose -f docker-compose.yml -f docker-compose.test.yml -f docker-compose.broker.yml up -d`.
+To run the tests, you need to launch the test database with `docker compose --profile test up -d`.
 
 Make sure the dev dependencies are installed with `uv sync --extra dev` or `pip3 install -e .[dev]`.
 
@@ -513,14 +513,17 @@ The payload should look something like:
 
 ## 🛠️ Development
 
-### 🐳 docker compose
+### 🐳 Docker compose
 
-Multiple docker-compose files are provided:
-- a minimal `docker-compose.yml` with two PostgreSQL containers (one for catalog and metadata, the other for converted CSV to database)
-- `docker-compose.broker.yml` adds a Redis broker
-- `docker-compose.test.yml` launches a test DB, needed to run tests
+A single `docker-compose.yml` file is provided with profiles to manage different environments:
+- Default services: `database` and `database-csv` (PostgreSQL containers for catalog/metadata and CSV conversion)
+- `test` profile: `test-database` (ephemeral test database)
+- `broker` profile: `broker` (Redis broker)
 
-NB: you can launch compose from multiple files like this: `docker compose -f docker-compose.yml -f docker-compose.test.yml up`
+Usage:
+- Development: `docker compose up -d` (or `docker compose --profile broker up -d` if Redis is needed)
+- Tests: `docker compose --profile test up -d` (broker not needed, queue functionality is mocked)
+- Broker only: `docker compose --profile broker up -d`
 
 ### 📝 Logging & Debugging
 

--- a/docker-compose.broker.yml
+++ b/docker-compose.broker.yml
@@ -1,5 +1,0 @@
-services:
-  broker:
-    image: redis
-    ports:
-      - 6379:6379

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,9 +1,0 @@
-services:
-  test_database:
-    image: "postgres:15" # target production version
-    environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB=postgres
-    ports:
-      - 5433:5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - database-data-15:/var/lib/postgresql/data/ # persist data even if container shuts down
     ports:
       - 5432:5432
+
   database-csv:
     image: "postgres:15"
     environment:
@@ -19,6 +20,24 @@ services:
       - database-data-csv-15:/var/lib/postgresql/data/ # persist data even if container shuts down
     ports:
       - 5434:5432
+
+  test-database:
+    image: "postgres:15"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=postgres
+    ports:
+      - 5433:5432
+    profiles:
+      - test
+
+  broker:
+    image: redis
+    ports:
+      - 6379:6379
+    profiles:
+      - broker
 
 volumes:
   database-data-15: # named volumes can be managed more easily using docker-compose


### PR DESCRIPTION
## Refactor docker-compose files to use profiles

- Consolidate `docker-compose.yml`, `docker-compose.test.yml`, and `docker-compose.broker.yml` into a single file using Docker Compose profiles.
- Rename `test_database` to `test-database` for naming consistency.
- Update README with simplified usage instructions.