### PR TITLE
Fix stable resource URL syntax

### DIFF
--- a/udata_hydra/crawl/check_resources.py
+++ b/udata_hydra/crawl/check_resources.py
@@ -216,7 +216,7 @@ async def handle_wrong_resource_url(
     worker_priority: str,
 ):
     resource_id = resource["resource_id"]
-    stable_resource_url = f"{config.UDATA_URI.replace('api/2', 'fr')}/datasets/r/{resource_id}"
+    stable_resource_url = f"{config.UDATA_URI.replace('api/2', 'api/1')}/datasets/r/{resource_id}"
     async with session.head(stable_resource_url) as resp:
         resp.raise_for_status()
         actual_url = resp.headers.get("location")


### PR DESCRIPTION
We were still using the old `/fr/datasets/r/<resource_id>` which is now redirected to the new `/api/1/datasets/r/<resource_id>`, leading to having stable URLs in the checks, for instance [here](https://crawler.data.gouv.fr/api/checks/all/?resource_id=c0f355f1-66bd-4f57-8a3c-2c6f3527b364)