### PR TITLE
chore(ogc): silence log warning

### DIFF
--- a/udata_hydra/logger.py
+++ b/udata_hydra/logger.py
@@ -45,6 +45,7 @@ class OwsLibPyprojFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         return "pyproj not installed" not in record.getMessage()
 
+
 logging.getLogger("owslib.feature.wfs100").addFilter(OwsLibPyprojFilter())
 
 


### PR DESCRIPTION
Indeed pyproj is not needed in our case since we don't need CRS handling