### PR TITLE
 feat: generate parquet from PostgreSQL table instead of re-reading CSV 

### DIFF
--- a/tests/test_analysis/test_parquet_export.py
+++ b/tests/test_analysis/test_parquet_export.py
@@ -8,11 +8,12 @@ from csv_detective import routine as csv_detective_routine
 from tests.conftest import RESOURCE_ID
 from udata_hydra.analysis.csv import (
     RESERVED_COLS,
+    csv_to_db,
     csv_to_parquet,
     generate_records,
 )
 from udata_hydra.utils.minio import MinIOClient
-from udata_hydra.utils.parquet import save_as_parquet
+from udata_hydra.utils.parquet import save_as_parquet, save_as_parquet_from_db
 
 pytestmark = pytest.mark.asyncio
 
@@ -48,6 +49,36 @@ async def test_save_as_parquet(file_and_count):
     assert len(table) == expected_count
     fake_file = BytesIO()
     pq.write_table(table, fake_file)
+
+
+async def test_save_as_parquet_from_db(clean_db):
+    file_path = "tests/data/catalog.csv"
+    table_name = "test_parquet_from_db"
+    inspection = csv_detective_routine(
+        file_path=file_path,
+        output_profile=True,
+        num_rows=-1,
+        save_results=False,
+    )
+    assert inspection
+
+    await csv_to_db(file_path, inspection=inspection, table_name=table_name)
+
+    _, table_from_db = await save_as_parquet_from_db(
+        table_name=table_name,
+        inspection=inspection,
+        output_filename=None,
+    )
+
+    _, table_from_csv = save_as_parquet(
+        records=generate_records(file_path, inspection),
+        columns=inspection["columns"],
+        output_filename=None,
+    )
+
+    assert table_from_db.num_rows == table_from_csv.num_rows
+    assert table_from_db.schema == table_from_csv.schema
+    assert table_from_db.to_pydict() == table_from_csv.to_pydict()
 
 
 @pytest.mark.parametrize(

--- a/udata_hydra/analysis/csv.py
+++ b/udata_hydra/analysis/csv.py
@@ -169,7 +169,7 @@ async def analyse_csv(
                 inspection=csv_inspection,
                 resource_id=resource_id,
                 check_id=check["id"],
-                table_name=table_name if config.CSV_TO_DB else None,
+                table_name=table_name if config.CSV_TO_DB and config.PARQUET_FROM_DB else None,
             )
             timer.mark("csv-to-parquet")
         except Exception as e:

--- a/udata_hydra/analysis/csv.py
+++ b/udata_hydra/analysis/csv.py
@@ -48,7 +48,7 @@ from udata_hydra.utils import (
 )
 from udata_hydra.utils.casting import generate_records
 from udata_hydra.utils.minio import MinIOClient
-from udata_hydra.utils.parquet import save_as_parquet
+from udata_hydra.utils.parquet import save_as_parquet, save_as_parquet_from_db
 
 log = logging.getLogger("udata-hydra")
 
@@ -169,6 +169,7 @@ async def analyse_csv(
                 inspection=csv_inspection,
                 resource_id=resource_id,
                 check_id=check["id"],
+                table_name=table_name if config.CSV_TO_DB else None,
             )
             timer.mark("csv-to-parquet")
         except Exception as e:
@@ -301,14 +302,20 @@ async def csv_to_parquet(
     inspection: dict,
     resource_id: str | None = None,
     check_id: int | None = None,
+    table_name: str | None = None,
 ) -> tuple[str, int] | None:
     """
     Convert a csv file to parquet using inspection data.
 
+    If table_name is provided, reads directly from the PostgreSQL table
+    instead of re-reading and re-casting the CSV file.
+
     Args:
         file_path: CSV file path to convert.
         inspection: CSV detective report.
-        table_name: used to name the parquet file.
+        resource_id: used to name the parquet file.
+        check_id: check ID to update with parquet info.
+        table_name: if provided, read from this PostgreSQL table instead of file_path.
 
     Returns:
         parquet_url: URL of the parquet file.
@@ -333,12 +340,18 @@ async def csv_to_parquet(
         # Update resource status to CONVERTING_TO_PARQUET
         await Resource.update(resource_id, {"status": "CONVERTING_TO_PARQUET"})
 
-    # save the file as parquet and store it on Minio instance
-    parquet_file, _ = save_as_parquet(
-        records=generate_records(file_path, inspection, cast_json=False),
-        columns=inspection["columns"],
-        output_filename=resource_id,
-    )
+    if table_name:
+        parquet_file, _ = await save_as_parquet_from_db(
+            table_name=table_name,
+            inspection=inspection,
+            output_filename=resource_id,
+        )
+    else:
+        parquet_file, _ = save_as_parquet(
+            records=generate_records(file_path, inspection, cast_json=False),
+            columns=inspection["columns"],
+            output_filename=resource_id,
+        )
     parquet_size: int = os.path.getsize(parquet_file)
     parquet_url: str = minio_client.send_file(parquet_file)
 

--- a/udata_hydra/analysis/csv.py
+++ b/udata_hydra/analysis/csv.py
@@ -169,7 +169,7 @@ async def analyse_csv(
                 inspection=csv_inspection,
                 resource_id=resource_id,
                 check_id=check["id"],
-                table_name=table_name if config.CSV_TO_DB and config.PARQUET_FROM_DB else None,
+                table_name=table_name if config.CSV_TO_DB and config.DB_TO_PARQUET else None,
             )
             timer.mark("csv-to-parquet")
         except Exception as e:
@@ -321,8 +321,8 @@ async def csv_to_parquet(
         parquet_url: URL of the parquet file.
         parquet_size: size of the parquet file.
     """
-    if not config.CSV_TO_PARQUET:
-        log.debug("CSV_TO_PARQUET turned off, skipping parquet export.")
+    if not config.CSV_TO_PARQUET and not config.DB_TO_PARQUET:
+        log.debug("CSV_TO_PARQUET and DB_TO_PARQUET turned off, skipping parquet export.")
         return
 
     if int(inspection.get("total_lines", 0)) < config.MIN_LINES_FOR_PARQUET:
@@ -340,7 +340,7 @@ async def csv_to_parquet(
         # Update resource status to CONVERTING_TO_PARQUET
         await Resource.update(resource_id, {"status": "CONVERTING_TO_PARQUET"})
 
-    if table_name:
+    if config.DB_TO_PARQUET and table_name:
         parquet_file, _ = await save_as_parquet_from_db(
             table_name=table_name,
             inspection=inspection,

--- a/udata_hydra/config_default.toml
+++ b/udata_hydra/config_default.toml
@@ -91,7 +91,7 @@ MINIO_PWD = ""
 
 # -- Parquet conversion settings -- #
 CSV_TO_PARQUET = false
-PARQUET_FROM_DB = false
+DB_TO_PARQUET = false
 MIN_LINES_FOR_PARQUET = 200
 MINIO_PARQUET_BUCKET = ""
 MINIO_PARQUET_FOLDER = "" # no trailing slash

--- a/udata_hydra/config_default.toml
+++ b/udata_hydra/config_default.toml
@@ -91,6 +91,7 @@ MINIO_PWD = ""
 
 # -- Parquet conversion settings -- #
 CSV_TO_PARQUET = false
+PARQUET_FROM_DB = false
 MIN_LINES_FOR_PARQUET = 200
 MINIO_PARQUET_BUCKET = ""
 MINIO_PARQUET_FOLDER = "" # no trailing slash

--- a/udata_hydra/routes/status.py
+++ b/udata_hydra/routes/status.py
@@ -166,6 +166,7 @@ async def get_health(request: web.Request) -> web.Response:
             "csv_analysis": config.CSV_ANALYSIS,
             "csv_to_db": config.CSV_TO_DB,
             "csv_to_parquet": config.CSV_TO_PARQUET,
+            "db_to_parquet": config.DB_TO_PARQUET,
             "geojson_to_pmtiles": config.GEOJSON_TO_PMTILES,
             "csv_to_geojson": config.CSV_TO_GEOJSON,
             "parquet_to_db": config.PARQUET_TO_DB,

--- a/udata_hydra/utils/parquet.py
+++ b/udata_hydra/utils/parquet.py
@@ -33,6 +33,42 @@ def save_as_parquet(
     return f"{output_filename}.parquet", table
 
 
+RESERVED_COLS = ("__id", "cmin", "cmax", "collation", "ctid", "tableoid", "xmin", "xmax")
+
+
+async def save_as_parquet_from_db(
+    table_name: str,
+    inspection: dict,
+    output_filename: str | None = None,
+) -> tuple[str, pa.Table]:
+    """Build a Parquet file by reading directly from the PostgreSQL CSV table,
+    avoiding a second read + cast pass over the original file."""
+    from udata_hydra import context
+
+    db = await context.pool("csv")
+
+    original_cols = list(inspection["columns"].keys())
+    db_cols = [f"{c}__hydra_renamed" if c.lower() in RESERVED_COLS else c for c in original_cols]
+    cols_sql = ", ".join(f'"{c}"' for c in db_cols)
+
+    rows = await db.fetch(f'SELECT {cols_sql} FROM "{table_name}"')
+
+    schema = pa.schema(
+        [
+            pa.field(c, PYTHON_TYPE_TO_PA[inspection["columns"][c]["python_type"]])
+            for c in original_cols
+        ]
+    )
+    table = pa.Table.from_pylist(
+        [{orig: row[db_col] for orig, db_col in zip(original_cols, db_cols)} for row in rows],
+        schema=schema,
+    )
+
+    if output_filename:
+        pq.write_table(table, f"{output_filename}.parquet", compression="zstd")
+    return f"{output_filename}.parquet", table
+
+
 async def detect_parquet_from_headers(check: dict) -> bool:
     headers: dict = json.loads(check["headers"] or "{}")
     # most parquet files are exposed with "application/octet-stream"

--- a/udata_hydra/utils/parquet.py
+++ b/udata_hydra/utils/parquet.py
@@ -36,6 +36,9 @@ def save_as_parquet(
 RESERVED_COLS = ("__id", "cmin", "cmax", "collation", "ctid", "tableoid", "xmin", "xmax")
 
 
+BATCH_SIZE = 50_000
+
+
 async def save_as_parquet_from_db(
     table_name: str,
     inspection: dict,
@@ -45,13 +48,11 @@ async def save_as_parquet_from_db(
     avoiding a second read + cast pass over the original file."""
     from udata_hydra import context
 
-    db = await context.pool("csv")
+    pool = await context.pool("csv")
 
     original_cols = list(inspection["columns"].keys())
     db_cols = [f"{c}__hydra_renamed" if c.lower() in RESERVED_COLS else c for c in original_cols]
     cols_sql = ", ".join(f'"{c}"' for c in db_cols)
-
-    rows = await db.fetch(f'SELECT {cols_sql} FROM "{table_name}"')
 
     schema = pa.schema(
         [
@@ -59,14 +60,32 @@ async def save_as_parquet_from_db(
             for c in original_cols
         ]
     )
-    table = pa.Table.from_pylist(
-        [{orig: row[db_col] for orig, db_col in zip(original_cols, db_cols)} for row in rows],
-        schema=schema,
-    )
+
+    parquet_path = f"{output_filename}.parquet"
+    writer = pq.ParquetWriter(parquet_path, schema, compression="zstd") if output_filename else None
+
+    try:
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                stmt = await conn.prepare(f'SELECT {cols_sql} FROM "{table_name}"')
+                cursor = await stmt.cursor()
+                while batch := await cursor.fetch(BATCH_SIZE):
+                    table = pa.table(
+                        {
+                            orig: [row[db_col] for row in batch]
+                            for orig, db_col in zip(original_cols, db_cols)
+                        },
+                        schema=schema,
+                    )
+                    if writer:
+                        writer.write_table(table)
+    finally:
+        if writer:
+            writer.close()
 
     if output_filename:
-        pq.write_table(table, f"{output_filename}.parquet", compression="zstd")
-    return f"{output_filename}.parquet", table
+        return parquet_path, pq.read_table(parquet_path)
+    return parquet_path, table
 
 
 async def detect_parquet_from_headers(check: dict) -> bool:


### PR DESCRIPTION
On `MN_07_latest-2025-2026.csv`: **14s → 9s** (-35%)
On `ValeursFoncieres-2024.txt`: **69s → 17s** (-75%)
On `irve.csv`: **14s → 2s** (-85%)
On `joconde.csv`: **35s → 14s** (-60%)