### PR TITLE
feat: add detailed timer marks for geojson and pmtiles conversion steps

### DIFF
--- a/udata_hydra/analysis/csv.py
+++ b/udata_hydra/analysis/csv.py
@@ -187,8 +187,8 @@ async def analyse_csv(
                 inspection=csv_inspection,
                 resource_id=resource_id,
                 check_id=check["id"],
+                timer=timer,
             )
-            timer.mark("csv-to-geojson-pmtiles")
         except Exception as e:
             remove_remainders(resource_id, ["geojson", "pmtiles", "pmtiles-journal"])
             raise ParseException(

--- a/udata_hydra/analysis/geojson.py
+++ b/udata_hydra/analysis/geojson.py
@@ -299,6 +299,7 @@ async def csv_to_geojson_and_pmtiles(
     inspection: dict,
     resource_id: str | None = None,
     check_id: int | None = None,
+    timer: Timer | None = None,
 ) -> tuple[Path, int, str | None, Path, int, str | None] | None:
     if not config.CSV_TO_GEOJSON:
         log.debug("CSV_TO_GEOJSON turned off, skipping geojson/PMtiles export.")
@@ -322,6 +323,8 @@ async def csv_to_geojson_and_pmtiles(
     if result is None:
         return None
     geojson_size, geojson_url = result
+    if timer:
+        timer.mark("csv-to-geojson")
 
     await Check.update(
         check_id,
@@ -337,6 +340,8 @@ async def csv_to_geojson_and_pmtiles(
 
     # Convert GeoJSON to PMTiles
     pmtiles_size, pmtiles_url = await geojson_to_pmtiles(geojson_filepath, pmtiles_filepath)
+    if timer:
+        timer.mark("geojson-to-pmtiles")
 
     await Check.update(
         check_id,


### PR DESCRIPTION
Split the opaque csv-to-geojson-pmtiles timer into two separate marks (csv-to-geojson and geojson-to-pmtiles) to identify bottlenecks.