### PR TITLE
refactor(utils): add `download_url_to_path` and refactor `utils/file.py`

### DIFF
--- a/tests/test_analysis/test_helpers.py
+++ b/tests/test_analysis/test_helpers.py
@@ -29,8 +29,7 @@ async def test_read_or_download_filename_resolution(mocker):
             check=mock_check, filename=basename, file_format="csv", exception=None
         )
 
-        assert result.read() == b"test content"
-        result.close()
+        assert result.read_bytes() == b"test content"
 
     finally:
         # Clean up

--- a/tests/test_crawl/test_crawl.py
+++ b/tests/test_crawl/test_crawl.py
@@ -1,9 +1,11 @@
 import hashlib
 import json
+import os
 import sys
 import tempfile
 from asyncio.exceptions import TimeoutError
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest.mock import ANY, patch
 
 import nest_asyncio2 as nest_asyncio
@@ -34,10 +36,10 @@ nest_asyncio.apply()
 
 
 async def mock_download_resource(url, headers, max_size_allowed):
-    tmp_file = tempfile.NamedTemporaryFile(delete=False)
-    tmp_file.write(SIMPLE_CSV_CONTENT.encode("utf-8"))
-    tmp_file.close()
-    return tmp_file, ""
+    fd, pathname = tempfile.mkstemp(suffix=".csv")
+    os.write(fd, SIMPLE_CSV_CONTENT.encode("utf-8"))
+    os.close(fd)
+    return Path(pathname), ""
 
 
 @pytest.mark.parametrize(

--- a/udata_hydra/analysis/csv.py
+++ b/udata_hydra/analysis/csv.py
@@ -127,7 +127,7 @@ async def analyse_csv(
             if previous_analysis:
                 await Resource.update(resource_id, {"status": "VALIDATING_CSV"})
                 csv_inspection = validate_then_detect(
-                    file_path=tmp_file.name,
+                    file_path=str(tmp_file),
                     previous_analysis=previous_analysis,
                     output_profile=True,
                     num_rows=-1,
@@ -135,7 +135,7 @@ async def analyse_csv(
                 )
             else:
                 csv_inspection = csv_detective_routine(
-                    file_path=tmp_file.name,
+                    file_path=str(tmp_file),
                     output_profile=True,
                     num_rows=-1,
                     save_results=False,
@@ -151,7 +151,7 @@ async def analyse_csv(
         timer.mark("csv-inspection")
 
         await csv_to_db(
-            file_path=tmp_file.name,
+            file_path=str(tmp_file),
             inspection=csv_inspection,
             table_name=table_name,
             table_indexes=table_indexes,
@@ -164,7 +164,7 @@ async def analyse_csv(
 
         try:
             await csv_to_parquet(
-                file_path=tmp_file.name,
+                file_path=str(tmp_file),
                 inspection=csv_inspection,
                 resource_id=resource_id,
                 check_id=check["id"],
@@ -183,7 +183,7 @@ async def analyse_csv(
 
         try:
             await csv_to_geojson_and_pmtiles(
-                file_path=tmp_file.name,
+                file_path=str(tmp_file),
                 inspection=csv_inspection,
                 resource_id=resource_id,
                 check_id=check["id"],
@@ -213,8 +213,7 @@ async def analyse_csv(
         await helpers.notify_udata(resource, check)
         timer.stop()
         if tmp_file is not None:
-            tmp_file.close()
-            os.remove(tmp_file.name)
+            tmp_file.unlink(missing_ok=True)
 
         # Reset resource status to None
         await Resource.update(resource_id, {"status": None})

--- a/udata_hydra/analysis/geojson.py
+++ b/udata_hydra/analysis/geojson.py
@@ -93,7 +93,7 @@ async def analyse_geojson(
         try:
             pmtiles_filepath = Path(f"{resource_id}.pmtiles")
             pmtiles_size, pmtiles_url = await geojson_to_pmtiles(
-                input_file_path=Path(tmp_file.name),
+                input_file_path=tmp_file,
                 output_file_path=pmtiles_filepath,
             )
             timer.mark("geojson-to-pmtiles")
@@ -122,8 +122,7 @@ async def analyse_geojson(
         await helpers.notify_udata(resource, check)
         timer.stop()
         if tmp_file is not None:
-            tmp_file.close()
-            os.remove(tmp_file.name)
+            tmp_file.unlink(missing_ok=True)
 
         # Reset resource status to None
         await Resource.update(resource_id, {"status": None})

--- a/udata_hydra/analysis/helpers.py
+++ b/udata_hydra/analysis/helpers.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import IO
+from pathlib import Path
 
 from asyncpg import Record
 
@@ -22,29 +22,26 @@ async def read_or_download_file(
     filename: str | None,
     file_format: str,
     exception: Record | None,
-) -> IO[bytes]:
+) -> Path:
     if filename:
         temp_dir = config.TEMPORARY_DOWNLOAD_FOLDER or "/tmp"
         full_path = os.path.join(temp_dir, filename)
-        try:
-            return open(full_path, "rb")
-        except FileNotFoundError:
+        if not Path(full_path).is_file():
             raise IOException(
                 f"Temporary file not found: {full_path}",
                 resource_id=check["resource_id"],
                 url=check["url"],
             )
-    else:
-        tmp_file, _ = await download_resource(
-            url=check["url"],
-            headers=json.loads(check.get("headers") or "{}"),
-            max_size_allowed=None
-            if exception
-            else int(
-                config.MAX_FILESIZE_ALLOWED.get(file_format, config.DEFAULT_MAX_FILESIZE_ALLOWED)
-            ),
-        )
-        return tmp_file
+        return Path(full_path)
+
+    dl_path, _ = await download_resource(
+        url=check["url"],
+        headers=json.loads(check.get("headers") or "{}"),
+        max_size_allowed=None
+        if exception
+        else int(config.MAX_FILESIZE_ALLOWED.get(file_format, config.DEFAULT_MAX_FILESIZE_ALLOWED)),
+    )
+    return dl_path
 
 
 async def notify_udata(resource: Record | None, check: Record | dict | None) -> None:

--- a/udata_hydra/analysis/parquet.py
+++ b/udata_hydra/analysis/parquet.py
@@ -1,7 +1,6 @@
 import hashlib
 import json
 import logging
-import os
 import re
 from datetime import datetime, timezone
 from typing import Iterator
@@ -88,7 +87,7 @@ async def analyse_parquet(
 
         # open the file and read the metadata
         try:
-            parquet_file = pq.ParquetFile(tmp_file.name)
+            parquet_file = pq.ParquetFile(tmp_file)
             columns = {}
             for col in parquet_file.schema_arrow:
                 col_type = str(col.type)
@@ -149,8 +148,7 @@ async def analyse_parquet(
         await helpers.notify_udata(resource, check)
         timer.stop()
         if tmp_file is not None:
-            tmp_file.close()
-            os.remove(tmp_file.name)
+            tmp_file.unlink(missing_ok=True)
 
         # Reset resource status to None
         await Resource.update(resource_id, {"status": None})

--- a/udata_hydra/analysis/resource.py
+++ b/udata_hydra/analysis/resource.py
@@ -1,8 +1,8 @@
 import json
 import logging
-import os
 from datetime import datetime, timezone
 from enum import Enum
+from pathlib import Path
 
 import magic
 from asyncpg import Record
@@ -109,7 +109,7 @@ async def analyse_resource(
 
     # if the change status is NO_GUESS or HAS_CHANGED, let's download the file to get more infos
     dl_analysis = {}
-    tmp_file = None
+    tmp_file: Path | None = None
     if change_status != Change.HAS_NOT_CHANGED or force_analysis:
         try:
             await Resource.update(resource_id, data={"status": "DOWNLOADING_RESOURCE"})
@@ -120,9 +120,9 @@ async def analyse_resource(
         else:
             await Resource.update(resource_id, data={"status": "ANALYSING_DOWNLOADED_RESOURCE"})
             # Get file size
-            dl_analysis["analysis:content-length"] = os.path.getsize(tmp_file.name)
+            dl_analysis["analysis:content-length"] = tmp_file.stat().st_size
             # Get checksum
-            dl_analysis["analysis:checksum"] = compute_checksum_from_file(tmp_file.name)
+            dl_analysis["analysis:checksum"] = compute_checksum_from_file(str(tmp_file))
             # Check if checksum has been modified if we don't have other hints
             if change_status == Change.NO_GUESS:
                 (
@@ -131,10 +131,10 @@ async def analyse_resource(
                 ) = await detect_resource_change_from_checksum(
                     new_checksum=dl_analysis["analysis:checksum"], last_check=last_check
                 )
-            dl_analysis["analysis:mime-type"] = magic.from_file(tmp_file.name, mime=True)
+            dl_analysis["analysis:mime-type"] = magic.from_file(tmp_file, mime=True)
         finally:
             if tmp_file and not (is_tabular or is_geojson or is_parquet):
-                os.remove(tmp_file.name)
+                tmp_file.unlink(missing_ok=True)
             await Check.update(
                 check["id"],
                 {
@@ -172,7 +172,7 @@ async def analyse_resource(
             queue.enqueue(
                 analyse_csv,
                 check=check,
-                filename=os.path.basename(tmp_file.name),
+                filename=tmp_file.name,
                 _priority="high" if worker_priority == "high" else "default",
                 _exception=bool(exception),
             )
@@ -181,7 +181,7 @@ async def analyse_resource(
             queue.enqueue(
                 analyse_geojson,
                 check=check,
-                filename=os.path.basename(tmp_file.name),
+                filename=tmp_file.name,
                 _priority="high" if worker_priority == "high" else "default",
                 _exception=bool(exception),
             )
@@ -190,7 +190,7 @@ async def analyse_resource(
             queue.enqueue(
                 analyse_parquet,
                 check=check,
-                filename=os.path.basename(tmp_file.name),
+                filename=tmp_file.name,
                 _priority="high" if worker_priority == "high" else "default",
                 _exception=bool(exception),
             )

--- a/udata_hydra/cli.py
+++ b/udata_hydra/cli.py
@@ -34,7 +34,7 @@ from udata_hydra.db.check import Check
 from udata_hydra.db.resource import Resource
 from udata_hydra.logger import setup_logging
 from udata_hydra.migrations import Migrator
-from udata_hydra.utils import download_file, download_resource
+from udata_hydra.utils import download_resource, download_url_to_fileobj
 
 cli = typer.Typer()
 context = {"conn": {}}
@@ -138,7 +138,7 @@ async def _load_catalog(
     try:
         log.info(f"Downloading resources catalog from {url}...")
         with NamedTemporaryFile(dir=config.TEMPORARY_DOWNLOAD_FOLDER or None, delete=False) as fd:
-            await download_file(url, fd)
+            await download_url_to_fileobj(url, fd)
         log.info("Upserting resources catalog in database...")
         # consider everything deleted, deleted will be updated when loading new catalog
         conn = await connection()
@@ -723,7 +723,7 @@ async def _csv_sample(
         lines.append(line)
         if not download:
             continue
-        await download_file(r["url"], filename.open("wb"))
+        await download_url_to_fileobj(r["url"], filename.open("wb"))
         with os.popen(f"file {filename} -b --mime-type") as proc:
             line["magic_mime"] = proc.read().lower().strip()
         line["real_size"] = filename.stat().st_size

--- a/udata_hydra/cli.py
+++ b/udata_hydra/cli.py
@@ -240,13 +240,13 @@ async def _download_resource_cli(resource_id: str, output_dir: str | None = None
         return
 
     try:
-        tmp_file, file_extension = await download_resource(resource["url"])
+        dl_path, file_extension = await download_resource(resource["url"])
         output_path = (
             Path(output_dir or config.TEMPORARY_DOWNLOAD_FOLDER or ".")
             / f"{resource_id}{file_extension}"
         )
         # Move the temporary file to the desired output location
-        Path(tmp_file.name).rename(output_path)
+        dl_path.rename(output_path)
         log.info(f"Successfully downloaded resource {resource_id} to {output_path}")
     except Exception as e:
         log.error(f"Failed to download resource {resource_id}: {e}")

--- a/udata_hydra/utils/__init__.py
+++ b/udata_hydra/utils/__init__.py
@@ -5,6 +5,7 @@ from .file import (
     compute_checksum_from_file,
     download_file,
     download_resource,
+    download_url_to_tempfile,
     extract_gzip,
     remove_remainders,
 )
@@ -24,6 +25,7 @@ __all__ = [
     "compute_checksum_from_file",
     "download_file",
     "download_resource",
+    "download_url_to_tempfile",
     "extract_gzip",
     "remove_remainders",
     "detect_geojson_from_headers",

--- a/udata_hydra/utils/__init__.py
+++ b/udata_hydra/utils/__init__.py
@@ -3,9 +3,9 @@ from .csv import detect_tabular_from_headers
 from .errors import IOException, ParseException, handle_parse_exception
 from .file import (
     compute_checksum_from_file,
-    download_file,
     download_resource,
-    download_url_to_tempfile,
+    download_url_to_fileobj,
+    download_url_to_path,
     extract_gzip,
     remove_remainders,
 )
@@ -23,9 +23,9 @@ __all__ = [
     "ParseException",
     "handle_parse_exception",
     "compute_checksum_from_file",
-    "download_file",
     "download_resource",
-    "download_url_to_tempfile",
+    "download_url_to_fileobj",
+    "download_url_to_path",
     "extract_gzip",
     "remove_remainders",
     "detect_geojson_from_headers",

--- a/udata_hydra/utils/file.py
+++ b/udata_hydra/utils/file.py
@@ -2,10 +2,10 @@ import gzip
 import hashlib
 import logging
 import mimetypes
-import os
 import re
 import tempfile
-from typing import IO
+from pathlib import Path
+from typing import IO, BinaryIO
 
 import aiohttp
 import magic
@@ -14,6 +14,8 @@ from udata_hydra import config
 from udata_hydra.utils import IOException
 
 log = logging.getLogger("udata-hydra")
+
+HTTP_DOWNLOAD_CHUNK_SIZE = 1024
 
 
 def compute_checksum_from_file(filename: str) -> str:
@@ -27,13 +29,64 @@ def compute_checksum_from_file(filename: str) -> str:
     return sha1sum.hexdigest()
 
 
-def extract_gzip(file_path: str) -> IO[bytes]:
+def extract_gzip(file_path: str | Path) -> IO[bytes]:
     with gzip.open(file_path, "rb") as gz_file:
         with tempfile.NamedTemporaryFile(
             dir=config.TEMPORARY_DOWNLOAD_FOLDER or None, mode="wb", delete=False
         ) as temp_file:
             temp_file.write(gz_file.read())
     return temp_file
+
+
+async def _http_get_to_temp_path(
+    url: str,
+    headers: dict | None,
+    max_size_allowed: int | None,
+    suffix: str,
+    io_error_message: str,
+) -> tuple[Path, int]:
+    """Stream a GET response to a named temp file. Returns (path, total_bytes)."""
+    if (
+        headers
+        and max_size_allowed is not None
+        and float(headers.get("content-length", -1)) > max_size_allowed
+    ):
+        raise IOException("File too large to download", url=url)
+
+    tmp_file: IO[bytes] = tempfile.NamedTemporaryFile(
+        dir=config.TEMPORARY_DOWNLOAD_FOLDER or None,
+        delete=False,
+        suffix=suffix,
+    )
+    path = Path(tmp_file.name)
+    total_bytes: int = 0
+    too_large: bool = False
+    download_error: aiohttp.ClientResponseError | None = None
+    try:
+        async with aiohttp.ClientSession(
+            headers={"user-agent": config.USER_AGENT_FULL},
+            raise_for_status=True,
+        ) as session:
+            async with session.get(url, allow_redirects=True) as response:
+                async for chunk in response.content.iter_chunked(HTTP_DOWNLOAD_CHUNK_SIZE):
+                    if max_size_allowed is None or total_bytes + len(chunk) <= max_size_allowed:
+                        tmp_file.write(chunk)
+                        total_bytes += len(chunk)
+                    else:
+                        too_large = True
+                        break
+    except aiohttp.ClientResponseError as e:
+        download_error = e
+    finally:
+        tmp_file.close()
+        if too_large or download_error:
+            path.unlink(missing_ok=True)
+        if too_large:
+            raise IOException("File too large to download", url=url)
+        if download_error:
+            raise IOException(io_error_message, url=url) from download_error
+
+    return path, total_bytes
 
 
 async def download_resource(
@@ -46,76 +99,68 @@ async def download_resource(
     Returns a tuple of (downloaded_file_object, detected_extension).
     Raises custom IOException if the resource is too large or if the URL is unreachable.
     """
-    if (
-        headers
-        and max_size_allowed is not None
-        and float(headers.get("content-length", -1)) > max_size_allowed
-    ):
-        raise IOException("File too large to download", url=url)
-
-    tmp_file = tempfile.NamedTemporaryFile(
-        dir=config.TEMPORARY_DOWNLOAD_FOLDER or None, delete=False
+    path, _ = await _http_get_to_temp_path(
+        url,
+        headers,
+        max_size_allowed,
+        "",
+        "Error downloading CSV",
     )
 
-    chunk_size = 1024
-    i = 0
-    too_large, download_error = False, None
-    try:
-        async with aiohttp.ClientSession(
-            headers={"user-agent": config.USER_AGENT_FULL},
-            raise_for_status=True,
-        ) as session:
-            async with session.get(url, allow_redirects=True) as response:
-                async for chunk in response.content.iter_chunked(chunk_size):
-                    if max_size_allowed is None or i * chunk_size < max_size_allowed:
-                        tmp_file.write(chunk)
-                    else:
-                        too_large = True
-                        break
-                    i += 1
-    except aiohttp.ClientResponseError as e:
-        download_error = e
-    finally:
-        tmp_file.close()
-        if too_large:
-            os.remove(tmp_file.name)
-            raise IOException("File too large to download", url=url)
-        if download_error:
-            os.remove(tmp_file.name)
-            raise IOException("Error downloading CSV", url=url) from download_error
+    detected_extension: str = ""
 
-    detected_extension = ""
-
-    if magic.from_file(tmp_file.name, mime=True) in [
+    if magic.from_file(path, mime=True) in [
         "application/x-gzip",
         "application/gzip",
     ]:
         # It's compressed - extract and determine extension from URL
-        gzip_tmp_file_name = tmp_file.name
-        tmp_file = extract_gzip(tmp_file.name)
+        tmp_file: IO[bytes] = extract_gzip(path)
         # Remove the gzip original temporary file
-        os.remove(gzip_tmp_file_name)
+        path.unlink()
 
         # Extract any extension before .gz using regex
-        match = re.search(r"\.([^.]+)\.gz$", url)
+        match: re.Match[str] | None = re.search(r"\.([^.]+)\.gz$", url)
         if match:
             detected_extension = f".{match.group(1)}"
         else:
             detected_extension = ""
     else:
         # Not compressed - use magic to detect type
-        mime_type = magic.from_file(tmp_file.name, mime=True)
+        mime_type: str = magic.from_file(path, mime=True)
         detected_extension = mimetypes.guess_extension(mime_type) or ""
+        tmp_file = open(path, "rb")
+        tmp_file.close()
 
     return tmp_file, detected_extension
 
 
-async def download_file(url: str, fd):
+async def download_url_to_tempfile(
+    url: str,
+    suffix: str = "",
+    headers: dict | None = None,
+    max_size_allowed: int | None = None,
+) -> Path:
+    """Download a URL to a named temporary file and return its path.
+
+    Streams the response body to disk to avoid loading large files into memory.
+    """
+    path, total_bytes = await _http_get_to_temp_path(
+        url,
+        headers,
+        max_size_allowed,
+        suffix,
+        "Error downloading file",
+    )
+    log.debug(f"Downloaded {url} to {path} ({total_bytes} bytes)")
+    return path
+
+
+async def download_file(url: str, fd: BinaryIO) -> None:
     """Download a file from URL to a file descriptor"""
     async with aiohttp.ClientSession() as session:
         async with session.get(url) as resp:
             while True:
-                chunk = await resp.content.read(1024)
+                chunk: bytes = await resp.content.read(HTTP_DOWNLOAD_CHUNK_SIZE)
                 if not chunk:
                     break
                 fd.write(chunk)
@@ -124,5 +169,4 @@ async def download_file(url: str, fd):
 def remove_remainders(resource_id: str, extensions: list[str]) -> None:
     """Delete potential remainders from process that crashed"""
     for ext in extensions:
-        if os.path.exists(f"{resource_id}.{ext}"):
-            os.remove(f"{resource_id}.{ext}")
+        Path(f"{resource_id}.{ext}").unlink(missing_ok=True)

--- a/udata_hydra/utils/file.py
+++ b/udata_hydra/utils/file.py
@@ -29,13 +29,17 @@ def compute_checksum_from_file(filename: str) -> str:
     return sha1sum.hexdigest()
 
 
-def extract_gzip(file_path: str | Path) -> IO[bytes]:
-    with gzip.open(file_path, "rb") as gz_file:
-        with tempfile.NamedTemporaryFile(
-            dir=config.TEMPORARY_DOWNLOAD_FOLDER or None, mode="wb", delete=False
-        ) as temp_file:
-            temp_file.write(gz_file.read())
-    return temp_file
+def extract_gzip(file_path: str | Path) -> Path:
+    tmp = tempfile.NamedTemporaryFile(
+        dir=config.TEMPORARY_DOWNLOAD_FOLDER or None, mode="wb", delete=False
+    )
+    out = Path(tmp.name)
+    try:
+        with gzip.open(file_path, "rb") as gz_file:
+            tmp.write(gz_file.read())
+    finally:
+        tmp.close()
+    return out
 
 
 async def _http_get_to_temp_path(
@@ -93,10 +97,10 @@ async def download_resource(
     url: str,
     headers: dict | None = None,
     max_size_allowed: int | None = None,
-) -> tuple[IO[bytes], str]:
+) -> tuple[Path, str]:
     """
     Attempts downloading a resource from a given url.
-    Returns a tuple of (downloaded_file_object, detected_extension).
+    Returns a tuple of (local path on disk after optional gunzip, detected_extension).
     Raises custom IOException if the resource is too large or if the URL is unreachable.
     """
     path, _ = await _http_get_to_temp_path(
@@ -114,8 +118,7 @@ async def download_resource(
         "application/gzip",
     ]:
         # It's compressed - extract and determine extension from URL
-        tmp_file: IO[bytes] = extract_gzip(path)
-        # Remove the gzip original temporary file
+        out_path = extract_gzip(path)
         path.unlink()
 
         # Extract any extension before .gz using regex
@@ -124,14 +127,13 @@ async def download_resource(
             detected_extension = f".{match.group(1)}"
         else:
             detected_extension = ""
+        path = out_path
     else:
         # Not compressed - use magic to detect type
         mime_type: str = magic.from_file(path, mime=True)
         detected_extension = mimetypes.guess_extension(mime_type) or ""
-        tmp_file = open(path, "rb")
-        tmp_file.close()
 
-    return tmp_file, detected_extension
+    return path, detected_extension
 
 
 async def download_url_to_tempfile(

--- a/udata_hydra/utils/file.py
+++ b/udata_hydra/utils/file.py
@@ -108,7 +108,7 @@ async def download_resource(
         headers,
         max_size_allowed,
         "",
-        "Error downloading CSV",
+        "Error downloading file",
     )
 
     detected_extension: str = ""

--- a/udata_hydra/utils/file.py
+++ b/udata_hydra/utils/file.py
@@ -136,15 +136,15 @@ async def download_resource(
     return path, detected_extension
 
 
-async def download_url_to_tempfile(
+async def download_url_to_path(
     url: str,
     suffix: str = "",
     headers: dict | None = None,
     max_size_allowed: int | None = None,
 ) -> Path:
-    """Download a URL to a named temporary file and return its path.
+    """Stream a URL response body to a new file on disk and return its path.
 
-    Streams the response body to disk to avoid loading large files into memory.
+    Uses a named temporary file under the configured download folder.
     """
     path, total_bytes = await _http_get_to_temp_path(
         url,
@@ -157,8 +157,8 @@ async def download_url_to_tempfile(
     return path
 
 
-async def download_file(url: str, fd: BinaryIO) -> None:
-    """Download a file from URL to a file descriptor"""
+async def download_url_to_fileobj(url: str, fd: BinaryIO) -> None:
+    """Stream a URL response body into a writable binary file object."""
     async with aiohttp.ClientSession() as session:
         async with session.get(url) as resp:
             while True:


### PR DESCRIPTION
- Added a `download_url_to_path` util for upcoming work (notably splitting GeoJSON/PMTiles into separate RQ jobs, e.g. [#408](https://github.com/datagouv/hydra/pull/408)). Those jobs can run after the main CSV pipeline has already removed the downloaded temp file, so when creating a PMtiles file if they can't find the geojson file anymore, they might need a small helper to stream the GeoJSON to a temp path as a fallback.

- Refactored `download_resource` in order to share the same streaming HTTP logic with the new `download_url_to_tempfile` to avoid duplicating aiohttp streaming code.

- Renamed `download_file`, which is used by `load_catalog`and `csv_sample` CLIs, to `download_url_to_fileobj` to be more clear and consistent along `download_url_to_path` 

- Returns `Path` instead of `NamedTemporaryFile`: easier hand‑off to tools that want a filesystem path, simpler cleanup, and no async lifetime mistakes with file objects.