### PR TITLE
chore(csv): remove redundant __all__ from csv analysis

### DIFF
--- a/udata_hydra/analysis/csv.py
+++ b/udata_hydra/analysis/csv.py
@@ -26,9 +26,6 @@ from udata_hydra.utils import (
     remove_remainders,
 )
 
-# Re-exported for backwards-compatible imports (e.g. udata_hydra/cli.py).
-__all__ = ["analyse_csv", "csv_detective_routine"]
-
 log = logging.getLogger("udata-hydra")
 
 


### PR DESCRIPTION
Undo the useless `__all__` / comment introduced in #422; named imports remain unchanged.