### PR TITLE
Add `header` field to parquet analysis

### DIFF
--- a/tests/test_analysis/test_analysis_parquet.py
+++ b/tests/test_analysis/test_analysis_parquet.py
@@ -89,7 +89,7 @@ async def test_analyse_parquet(
 
     # checking table content
     rows = list(await db.fetch(f'SELECT * FROM "{table_name}"'))
-    assert len(rows) == 4
+    assert len(rows) == len(df)
     pgtypes = await db.fetchrow(
         "SELECT "
         + ", ".join([f"pg_typeof({col}) as {col}" for col in expected_types.keys()])
@@ -101,7 +101,7 @@ async def test_analyse_parquet(
         "SELECT csv_detective FROM tables_index WHERE resource_id = $1", check["resource_id"]
     )
     inspection = json.loads(res["csv_detective"])
-    assert inspection["total_lines"] == 4
+    assert inspection["total_lines"] == len(df)
     assert inspection["header"] == list(df.columns)
 
     for col, types in expected_types.items():

--- a/tests/test_analysis/test_analysis_parquet.py
+++ b/tests/test_analysis/test_analysis_parquet.py
@@ -29,7 +29,7 @@ async def test_analyse_parquet(
     check = await fake_check(**check_kwargs)
     url = check["url"]
     table_name = hashlib.md5(url.encode("utf-8")).hexdigest()
-    parquet_file_content = pd.DataFrame(
+    df = pd.DataFrame(
         {
             "name": ["Marie", "Paul", "Léa", "Pierre"],
             "score": [1.2, 3.4, 5.6, 7.8],
@@ -66,7 +66,7 @@ async def test_analyse_parquet(
                 b"\xb7\xd4\x00",
             ],
         }
-    ).to_parquet()
+    )
     expected_types = {
         "name": {"python": "string", "pg": "character varying"},
         "score": {"python": "float", "pg": "double precision"},
@@ -78,7 +78,7 @@ async def test_analyse_parquet(
         "dicts": {"python": "json", "pg": "json"},
         "bina": {"python": "binary", "pg": "bytea"},
     }
-    rmock.get(url, status=200, body=parquet_file_content)
+    rmock.get(url, status=200, body=df.to_parquet())
     with patch("udata_hydra.config.PARQUET_TO_DB", True):
         await analyse_parquet(check=check)
 
@@ -101,6 +101,8 @@ async def test_analyse_parquet(
         "SELECT csv_detective FROM tables_index WHERE resource_id = $1", check["resource_id"]
     )
     inspection = json.loads(res["csv_detective"])
+    assert inspection["total_lines"] == 4
+    assert inspection["header"] == list(df.columns)
 
     for col, types in expected_types.items():
         assert pgtypes[col] == types["pg"]

--- a/udata_hydra/analysis/parquet.py
+++ b/udata_hydra/analysis/parquet.py
@@ -70,7 +70,9 @@ async def analyse_parquet(
         try:
             parquet_file = pq.ParquetFile(tmp_file.name)
             columns = {}
+            inspection = {"header": []}
             for col in parquet_file.schema_arrow:
+                inspection["header"].append(col.name)
                 col_type = str(col.type)
                 if col_type.startswith("dictionary"):
                     # dictionaries are for columns with repeated values
@@ -84,14 +86,12 @@ async def analyse_parquet(
                     )
                 except StopIteration:
                     raise ValueError(f"Unknown pyarrow type: {col.type}")
-            inspection = {
-                "columns": {
-                    col_name: {
-                        "format": pytype,
-                        "python_type": pytype,
-                    }
-                    for col_name, pytype in columns.items()
+            inspection["columns"] = {
+                col_name: {
+                    "format": pytype,
+                    "python_type": pytype,
                 }
+                for col_name, pytype in columns.items()
             }
             inspection["total_lines"] = parquet_file.metadata.num_rows
         except Exception as e:


### PR DESCRIPTION
Explore expects the `header` field