### PR TITLE
test: refactor tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -361,3 +361,26 @@ def udata_resource_payload():
             "last_modified": datetime.now().isoformat(),
         },
     }
+
+
+@pytest.fixture
+def udata_update_resource_payload():
+    return {
+        "resource_id": RESOURCE_ID,
+        "dataset_id": DATASET_ID,
+        "document": {
+            "id": RESOURCE_ID,
+            "url": RESOURCE_URL,
+            "title": "random title",
+            "description": "random description",
+            "filetype": "file",
+            "type": "documentation",
+            "format": "pdf",
+            "mime": "text/plain",
+            "filesize": 1024,
+            "checksum_type": "sha1",
+            "checksum_value": "b7b1cd8230881b18b6b487d550039949867ec7c5",
+            "created_at": datetime.now().isoformat(),
+            "last_modified": datetime.now().isoformat(),
+        },
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,9 @@ RESOURCE_EXCEPTION_TABLE_INDEXES = {"Nom": "index", "N° de certificat": "index"
 RESOURCE_URL = "https://example.com/resource-1"
 DATASET_ID = "601ddcfc85a59c3a45c2435a"
 NOT_EXISTING_RESOURCE_ID = "5d0b2b91-b21b-4120-83ef-83f818ba2451"
+SIMPLE_CSV_CONTENT = """code_insee,number
+95211,102
+36522,48"""
 pytestmark = pytest.mark.asyncio
 
 # nest_asyncio2 skips _patch_loop() in Python 3.14 when no event loop is running

--- a/tests/test_analysis/test_analysis_csv.py
+++ b/tests/test_analysis/test_analysis_csv.py
@@ -171,49 +171,6 @@ async def test_analyse_csv_send_udata_webhook(
         assert webhook.get(f"analysis:parsing:{k}", False) is None
 
 
-async def test_analyse_csv_enqueues_export_jobs_on_low_queue(
-    mocker, setup_catalog, rmock, catalog_content, db, fake_check, produce_mock
-):
-    """Parquet export is scheduled on the low RQ queue (CSV geo export disabled)."""
-    import asyncio
-
-    recorded: list[tuple[object, str | None]] = []
-
-    async def tracking_parquet_export(*args, **kwargs):
-        pass
-
-    mocker.patch("udata_hydra.analysis.csv.export_parquet", tracking_parquet_export)
-
-    def capture_enqueue(fn, *args, **kwargs):
-        recorded.append((fn, kwargs.get("_priority")))
-        kwargs = dict(kwargs)
-        kwargs.pop("_priority", None)
-        kwargs.pop("_exception", None)
-        result = fn(*args, **kwargs)
-        if asyncio.iscoroutine(result):
-            loop = asyncio.get_running_loop()
-            return loop.run_until_complete(result)
-        return result
-
-    mocker.patch("udata_hydra.utils.queue.enqueue", capture_enqueue)
-
-    check = await fake_check()
-    url = check["url"]
-    rmock.get(url, status=200, body=catalog_content)
-    with (
-        patch("udata_hydra.config.DB_TO_PARQUET", True),
-        patch("udata_hydra.config.MIN_LINES_FOR_PARQUET", 1),
-        patch("udata_hydra.config.DB_TO_GEOJSON", False),
-    ):
-        await analyse_csv(check=check)
-
-    assert any(f is tracking_parquet_export and p == "low" for f, p in recorded)
-
-    from udata_hydra.analysis.exports import export_geojson_pmtiles as exp_geo
-
-    assert not any(f is exp_geo for f, _ in recorded)
-
-
 @pytest.mark.parametrize(
     "forced_analysis",
     (
@@ -512,22 +469,27 @@ async def test_too_long_column_name(
 
 
 @pytest.mark.parametrize(
-    "db_to_parquet_enabled, expected_await_count",
+    "db_to_parquet_enabled, expected_parquet_jobs",
     (
-        (True, 1),
-        (False, 0),
+        pytest.param(True, 1, id="enabled"),
+        pytest.param(False, 0, id="disabled"),
     ),
 )
-async def test_analyse_csv_db_to_parquet_switch(
+async def test_analyse_csv_parquet_export_enqueue(
+    mocker,
     setup_catalog,
     rmock,
     catalog_content,
     fake_check,
     produce_mock,
     db_to_parquet_enabled,
-    expected_await_count,
+    expected_parquet_jobs,
 ):
-    """Parquet export is scheduled when DB_TO_PARQUET is enabled (low-priority enqueue path)."""
+    """Parquet export enqueue respects DB_TO_PARQUET, uses low priority, skips geo export."""
+    from udata_hydra.analysis.exports import export_geojson_pmtiles as exp_geo
+
+    mock_enqueue = mocker.patch("udata_hydra.analysis.csv.queue.enqueue")
+
     check = await fake_check()
     url = check["url"]
     table_name = hashlib.md5(url.encode("utf-8")).hexdigest()
@@ -536,16 +498,19 @@ async def test_analyse_csv_db_to_parquet_switch(
     with (
         patch("udata_hydra.config.DB_TO_PARQUET", db_to_parquet_enabled),
         patch("udata_hydra.config.MIN_LINES_FOR_PARQUET", 1),
-        patch("udata_hydra.analysis.csv.queue.enqueue") as mock_enqueue,
+        patch("udata_hydra.config.DB_TO_GEOJSON", False),
     ):
         await analyse_csv(check=check)
 
     parquet_jobs = [
         c for c in mock_enqueue.call_args_list if c.args and c.args[0] is export_parquet
     ]
-    assert len(parquet_jobs) == expected_await_count
+    assert len(parquet_jobs) == expected_parquet_jobs
+    assert not any(c.args and c.args[0] is exp_geo for c in mock_enqueue.call_args_list)
+
     if db_to_parquet_enabled:
         kw = parquet_jobs[0].kwargs
+        assert kw["_priority"] == "low"
         assert kw["table_name"] == table_name
         assert kw["resource_id"] == RESOURCE_ID
         assert kw["check_id"] == check["id"]

--- a/tests/test_analysis/test_analysis_csv.py
+++ b/tests/test_analysis/test_analysis_csv.py
@@ -20,9 +20,8 @@ from udata_hydra.db.resource import Resource
 pytestmark = pytest.mark.asyncio
 
 
-@pytest.mark.parametrize("debug_insert", [True, False])
 async def test_analyse_csv_on_catalog(
-    setup_catalog, rmock, catalog_content, db, debug_insert, fake_check, produce_mock
+    setup_catalog, rmock, catalog_content, db, fake_check, produce_mock
 ):
     check = await fake_check()
     url = check["url"]

--- a/tests/test_api/test_api_resources.py
+++ b/tests/test_api/test_api_resources.py
@@ -3,8 +3,6 @@ NB: we can't use pytest-aiohttp helpers because
 it will interfere with the rest of our async code
 """
 
-from datetime import datetime
-
 import pytest
 
 from tests.conftest import DATASET_ID, NOT_EXISTING_RESOURCE_ID, RESOURCE_ID, RESOURCE_URL
@@ -74,7 +72,9 @@ async def test_create_resource(
     assert text == "Missing document body"
 
 
-async def test_update_resource(client, api_headers, api_headers_wrong_token):
+async def test_update_resource(
+    client, api_headers, api_headers_wrong_token, udata_update_resource_payload
+):
     # Test invalid PUT data
     stupid_post_data: dict = {"stupid": "stupid"}
     resp = await client.put(
@@ -82,25 +82,7 @@ async def test_update_resource(client, api_headers, api_headers_wrong_token):
     )
     assert resp.status == 400
 
-    payload = {
-        "resource_id": RESOURCE_ID,
-        "dataset_id": DATASET_ID,
-        "document": {
-            "id": RESOURCE_ID,
-            "url": RESOURCE_URL,
-            "title": "random title",
-            "description": "random description",
-            "filetype": "file",
-            "type": "documentation",
-            "format": "pdf",
-            "mime": "text/plain",
-            "filesize": 1024,
-            "checksum_type": "sha1",
-            "checksum_value": "b7b1cd8230881b18b6b487d550039949867ec7c5",
-            "created_at": datetime.now().isoformat(),
-            "last_modified": datetime.now().isoformat(),
-        },
-    }
+    payload = udata_update_resource_payload
 
     # Test API call with no token
     resp = await client.put(path=f"/api/resources/{RESOURCE_ID}", headers=None, json=payload)
@@ -126,7 +108,9 @@ async def test_update_resource(client, api_headers, api_headers_wrong_token):
     assert text == "Missing document body"
 
 
-async def test_update_resource_url_since_load_catalog(setup_catalog, db, client, api_headers):
+async def test_update_resource_url_since_load_catalog(
+    setup_catalog, db, client, api_headers, udata_update_resource_payload
+):
     # We modify the url for this resource
     await db.execute(
         "UPDATE catalog SET url = 'https://example.com/resource-0' "
@@ -134,25 +118,7 @@ async def test_update_resource_url_since_load_catalog(setup_catalog, db, client,
     )
 
     # We're sending an update signal on the (dataset_id,resource_id) with the previous url.
-    payload = {
-        "resource_id": RESOURCE_ID,
-        "dataset_id": DATASET_ID,
-        "document": {
-            "id": RESOURCE_ID,
-            "url": RESOURCE_URL,
-            "title": "random title",
-            "description": "random description",
-            "filetype": "file",
-            "type": "documentation",
-            "format": "pdf",
-            "mime": "text/plain",
-            "filesize": 1024,
-            "checksum_type": "sha1",
-            "checksum_value": "b7b1cd8230881b18b6b487d550039949867ec7c5",
-            "created_at": datetime.now().isoformat(),
-            "last_modified": datetime.now().isoformat(),
-        },
-    }
+    payload = udata_update_resource_payload
     # It does not create any duplicated resource.
     # The existing entry get updated accordingly.
 

--- a/tests/test_api/test_api_resources.py
+++ b/tests/test_api/test_api_resources.py
@@ -45,6 +45,12 @@ async def test_create_resource(
     )
     assert resp.status == 403
 
+    for bad_headers in ({"Authorization": "Bearer"}, {"Authorization": "Basic wrong-token"}):
+        resp = await client.post(
+            path="/api/resources/", headers=bad_headers, json=udata_resource_payload
+        )
+        assert resp.status == 403
+
     # Test API call with invalid POST data
     stupid_post_data: dict = {"stupid": "stupid"}
     resp = await client.post(path="/api/resources/", headers=api_headers, json=stupid_post_data)

--- a/tests/test_cli/test_analysis.py
+++ b/tests/test_cli/test_analysis.py
@@ -11,14 +11,24 @@ pytestmark = pytest.mark.asyncio
 nest_asyncio.apply()
 
 
-async def test_csv_analysis_from_check_id(
-    setup_catalog, rmock, catalog_content, db, fake_check, produce_mock
+@pytest.mark.parametrize(
+    "entry_mode",
+    [
+        pytest.param("check_id", id="check_id"),
+        pytest.param("url", id="url"),
+    ],
+)
+async def test_csv_analysis_from_catalog(
+    setup_catalog, rmock, catalog_content, fake_check, produce_mock, entry_mode
 ):
-    """Test the analyse-csv CLI command using check_id"""
+    """Test the analyse-csv CLI command using check_id or URL for a catalog resource."""
     check = await fake_check()
     url = check["url"]
     rmock.get(url, status=200, body=catalog_content)
-    await analyse_csv_cli(check_id=str(check["id"]))
+    if entry_mode == "check_id":
+        await analyse_csv_cli(check_id=str(check["id"]))
+    else:
+        await analyse_csv_cli(check_id=None, url=url, debug_insert=False)
 
 
 async def test_csv_analysis_with_debug_insert(setup_catalog, rmock, db, fake_check, produce_mock):
@@ -51,16 +61,6 @@ async def test_csv_analysis_with_debug_insert(setup_catalog, rmock, db, fake_che
     assert len(table_data) == 3  # Should have 3 rows
     assert table_data[0]["name"] == "Alice"
     assert table_data[0]["value"] == 42
-
-
-async def test_csv_analysis_from_url(
-    setup_catalog, rmock, catalog_content, db, fake_check, produce_mock
-):
-    """Test the analyse-csv CLI command using URL, with an existing check"""
-    check = await fake_check()
-    url = check["url"]
-    rmock.get(url, status=200, body=catalog_content)
-    await analyse_csv_cli(check_id=None, url=url, debug_insert=False)
 
 
 async def test_csv_analysis_from_external_url(setup_catalog, rmock, db, produce_mock):

--- a/tests/test_cli/test_purge.py
+++ b/tests/test_cli/test_purge.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta, timezone
 
 import nest_asyncio2 as nest_asyncio
 import pytest
+import pytest_asyncio
 from asyncpg.exceptions import UndefinedTableError
 
 from tests.conftest import RESOURCE_ID, RESOURCE_URL
@@ -13,6 +14,40 @@ from udata_hydra.cli import (
 
 pytestmark = pytest.mark.asyncio
 nest_asyncio.apply()
+
+
+async def _create_parsed_csv_table(db, fake_check, *, with_tables_index: bool = False) -> dict:
+    """Fake CSV analysis table (+ optional tables_index row) for purge CLI tests."""
+    check = await fake_check(parsing_table=True)
+    md5 = check["parsing_table"]
+    await db.execute(f'CREATE TABLE "{md5}"(id serial)')
+    if with_tables_index:
+        await db.execute(
+            "INSERT INTO tables_index(parsing_table, csv_detective, resource_id, url) VALUES($1, $2, $3, $4)",
+            md5,
+            "{}",
+            check.get("resource_id"),
+            check.get("url"),
+        )
+    return {"check": check, "md5": md5, "url": check["url"]}
+
+
+async def _assert_pg_table_exists(db, md5: str) -> None:
+    res = await db.fetchrow("SELECT tablename FROM pg_catalog.pg_tables WHERE tablename = $1", md5)
+    assert res is not None
+
+
+async def _assert_pg_table_missing(db, md5: str) -> None:
+    res = await db.fetchrow("SELECT tablename FROM pg_catalog.pg_tables WHERE tablename = $1", md5)
+    assert res is None
+
+
+@pytest_asyncio.fixture
+async def csv_table_for_purge(db, fake_check):
+    async def setup(*, with_tables_index: bool = False) -> dict:
+        return await _create_parsed_csv_table(db, fake_check, with_tables_index=with_tables_index)
+
+    return setup
 
 
 async def test_purge_checks(setup_catalog, db, fake_check):
@@ -40,136 +75,90 @@ async def test_purge_checks(setup_catalog, db, fake_check):
         (True, None),  # hard_delete=True: table_index entry should be completely deleted
     ],
 )
-async def test_purge_csv_tables(setup_catalog, db, fake_check, hard_delete, expected_deleted_at):
+async def test_purge_csv_tables(
+    setup_catalog, db, csv_table_for_purge, hard_delete, expected_deleted_at
+):
     """Test the purge_csv_tables CLI command with different hard_delete values"""
-    # pretend we have a csv_analysis with a converted table for this url
-    check = await fake_check(parsing_table=True)
-    md5 = check["parsing_table"]
-    await db.execute(f'CREATE TABLE "{md5}"(id serial)')
+    table = await csv_table_for_purge(with_tables_index=True)
+    md5 = table["md5"]
+    await _assert_pg_table_exists(db, md5)
 
-    # Create the tables_index entry
-    await db.execute(
-        "INSERT INTO tables_index(parsing_table, csv_detective, resource_id, url) VALUES($1, $2, $3, $4)",
-        md5,
-        "{}",
-        check.get("resource_id"),
-        check.get("url"),
-    )
-
-    # check table is there before purge
-    res = await db.fetchrow("SELECT tablename FROM pg_catalog.pg_tables WHERE tablename = $1", md5)
-    assert res is not None
-
-    # pretend the resource's url has changed
     await db.execute(
         f"UPDATE catalog SET url = '{RESOURCE_URL + '-new'}' WHERE resource_id = '{RESOURCE_ID}'"
     )
 
-    # purge with the specified hard_delete parameter
     await purge_csv_tables(quiet=False, hard_delete=hard_delete)
 
-    # check table is gone
-    res = await db.fetchrow("SELECT tablename FROM pg_catalog.pg_tables WHERE tablename = $1", md5)
-    assert res is None
+    await _assert_pg_table_missing(db, md5)
 
-    # Check tables_index entry based on hard_delete parameter
     res = await db.fetchrow("SELECT * FROM tables_index WHERE parsing_table = $1", md5)
     if expected_deleted_at is None:
-        # Entry should be completely deleted
         assert res is None
     else:
-        # Entry should exist and be marked as deleted with a timestamp
         assert res is not None
-        assert res["deleted_at"] is not None  # Should have a timestamp
-        assert isinstance(res["deleted_at"], datetime)  # Should be a datetime object
+        assert res["deleted_at"] is not None
+        assert isinstance(res["deleted_at"], datetime)
 
 
-async def test_purge_csv_tables_url_used_by_other_resource(setup_catalog, db, fake_check):
+async def test_purge_csv_tables_url_used_by_other_resource(setup_catalog, db, csv_table_for_purge):
     """We should not delete csv table if the url is used by a resource still active"""
-    # pretend we have a csv_analysis with a converted table for this url
-    check = await fake_check(parsing_table=True)
-    md5 = check["parsing_table"]
-    await db.execute(f'CREATE TABLE "{md5}"(id serial)')
+    table = await csv_table_for_purge()
+    md5 = table["md5"]
+    await _assert_pg_table_exists(db, md5)
 
-    # check table is there before purge
-    res = await db.fetchrow("SELECT tablename FROM pg_catalog.pg_tables WHERE tablename = $1", md5)
-    assert res is not None
-
-    # pretend the resource is deleted
     await db.execute("UPDATE catalog SET deleted = TRUE")
 
-    # insert another resource with same url
     await db.execute(
         "INSERT INTO catalog (dataset_id, resource_id, url, deleted, priority) VALUES($1, $2, $3, $4, $5)",
         "6115eed4acb337ce13b83db3",
         "7a0c10a0-8e6f-403f-a987-2e223b22ee33",
-        check["url"],
+        table["url"],
         False,
         False,
     )
 
-    # purge
     await purge_csv_tables(quiet=False, hard_delete=False)
 
-    # check table is _not_ gone
-    res = await db.fetchrow("SELECT tablename FROM pg_catalog.pg_tables WHERE tablename = $1", md5)
-    assert res is not None
+    await _assert_pg_table_exists(db, md5)
 
 
-async def test_purge_csv_tables_url_used_by_deleted_resource_only(setup_catalog, db, fake_check):
+async def test_purge_csv_tables_url_used_by_deleted_resource_only(
+    setup_catalog, db, csv_table_for_purge
+):
     """We should delete csv table if all resource with this url are marked as deleted"""
-    # pretend we have a csv_analysis with a converted table for this url
-    check = await fake_check(parsing_table=True)
-    md5 = check["parsing_table"]
-    await db.execute(f'CREATE TABLE "{md5}"(id serial)')
+    table = await csv_table_for_purge()
+    md5 = table["md5"]
+    await _assert_pg_table_exists(db, md5)
 
-    # check table is there before purge
-    res = await db.fetchrow("SELECT tablename FROM pg_catalog.pg_tables WHERE tablename = $1", md5)
-    assert res is not None
-
-    # pretend the resource is deleted
     await db.execute("UPDATE catalog SET deleted = TRUE")
 
-    # insert another deleted resource with same url
     await db.execute(
         "INSERT INTO catalog (dataset_id, resource_id, url, deleted, priority) VALUES($1, $2, $3, $4, $5)",
         "6115eed4acb337ce13b83db3",
         "7a0c10a0-8e6f-403f-a987-2e223b22ee33",
-        check["url"],
+        table["url"],
         True,
         False,
     )
 
-    # purge
     await purge_csv_tables(quiet=False, hard_delete=False)
 
-    # check table is gone
-    res = await db.fetchrow("SELECT tablename FROM pg_catalog.pg_tables WHERE tablename = $1", md5)
-    assert res is None
+    await _assert_pg_table_missing(db, md5)
     res = await db.fetchrow("SELECT * FROM tables_index WHERE parsing_table = $1", md5)
     assert res is None
 
 
-async def test_purge_csv_tables_url_not_in_catalog(setup_catalog, db, fake_check):
+async def test_purge_csv_tables_url_not_in_catalog(setup_catalog, db, csv_table_for_purge):
     """We should delete csv table if the url is not the catalog anymore"""
-    # pretend we have a csv_analysis with a converted table for this url
-    check = await fake_check(parsing_table=True)
-    md5 = check["parsing_table"]
-    await db.execute(f'CREATE TABLE "{md5}"(id serial)')
+    table = await csv_table_for_purge()
+    md5 = table["md5"]
+    await _assert_pg_table_exists(db, md5)
 
-    # check table is there before purge
-    res = await db.fetchrow("SELECT tablename FROM pg_catalog.pg_tables WHERE tablename = $1", md5)
-    assert res is not None
-
-    # pretend the resource URL have been updated
     await db.execute("UPDATE catalog SET url = 'https://example.com/resource-0'")
 
-    # purge
     await purge_csv_tables(quiet=False, hard_delete=False)
 
-    # check table is gone
-    res = await db.fetchrow("SELECT tablename FROM pg_catalog.pg_tables WHERE tablename = $1", md5)
-    assert res is None
+    await _assert_pg_table_missing(db, md5)
     res = await db.fetchrow("SELECT * FROM tables_index WHERE parsing_table = $1", md5)
     assert res is None
 

--- a/tests/test_conversion/test_db_to_geojson.py
+++ b/tests/test_conversion/test_db_to_geojson.py
@@ -1,6 +1,8 @@
 import json
+from collections.abc import Callable
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from typing import cast
 
 import pytest
 from csv_detective import routine as csv_detective_routine
@@ -10,6 +12,64 @@ from udata_hydra.conversion.csv_to_db import csv_to_db
 from udata_hydra.conversion.db_to_geojson import db_to_geojson
 
 pytestmark = pytest.mark.asyncio
+
+
+def _build_csv_content(columns: dict, sep: str = ";") -> str:
+    row_count = len(next(iter(columns.values())))
+    content = sep.join(columns) + "\n"
+    for i in range(row_count):
+        content += sep.join(str(val) for val in [data[i] for data in columns.values()]) + "\n"
+    return content
+
+
+async def _geojson_from_columns(
+    db,
+    *,
+    columns: dict,
+    table_name: str,
+    inspection_check: Callable[[dict], None] | None = None,
+    sep: str = ";",
+) -> tuple[dict, tuple[int, str | None]]:
+    """Build CSV from columns, convert to DB + GeoJSON, return (geojson, db_to_geojson result)."""
+    output_path = Path(f"{RESOURCE_ID}.geojson")
+    try:
+        output_path.unlink()
+    except FileNotFoundError:
+        pass
+
+    with NamedTemporaryFile(delete=False) as fp:
+        fp.write(_build_csv_content(columns, sep).encode("utf-8"))
+        fp.seek(0)
+        inspection = cast(
+            dict,
+            csv_detective_routine(
+                file_path=fp.name,
+                output_profile=True,
+                num_rows=-1,
+                save_results=False,
+            ),
+        )
+        if inspection_check is not None:
+            inspection_check(inspection)
+
+        await csv_to_db(fp.name, inspection, table_name)
+        result = await db_to_geojson(table_name, inspection, output_path, upload_to_s3=False)
+
+    assert result is not None
+    with open(output_path) as f:
+        geojson: dict = json.load(f)
+
+    output_path.unlink()
+    await db.execute(f'DROP TABLE IF EXISTS "{table_name}"')
+    return geojson, result
+
+
+def _assert_lonlat_format(inspection: dict) -> None:
+    assert "lonlat" in inspection["columns"]["geopoint"]["format"]
+
+
+def _assert_geojson_column_format(inspection: dict) -> None:
+    assert "geojson" in inspection["columns"]["polyg"]["format"]
 
 
 @pytest.mark.parametrize(
@@ -25,46 +85,20 @@ pytestmark = pytest.mark.asyncio
     ),
 )
 async def test_db_to_geojson(db, geo_columns, clean_db):
-    output_path = Path(f"{RESOURCE_ID}.geojson")
-    try:
-        output_path.unlink()
-    except FileNotFoundError:
-        pass
-
     expected_lats = [10.0 * k * (-1) ** k for k in range(1, 6)]
     expected_lons = [20.0 * k * (-1) ** k for k in range(1, 6)]
-
     other_columns = {
         "nombre": range(1, 6),
         "score": [0.01, 1.2, 34.5, 678.9, 10],
     }
-    sep = ";"
-    columns = other_columns | geo_columns
-    file = sep.join(columns) + "\n"
-    for i in range(len(other_columns["nombre"])):
-        file += sep.join(str(val) for val in [data[i] for data in columns.values()]) + "\n"
-
-    with NamedTemporaryFile(delete=False) as fp:
-        fp.write(file.encode("utf-8"))
-        fp.seek(0)
-        inspection = csv_detective_routine(
-            file_path=fp.name,
-            output_profile=True,
-            num_rows=-1,
-            save_results=False,
-        )
-
-    table_name = "test_geojson_from_db"
-    await csv_to_db(fp.name, inspection, table_name)
-
-    result = await db_to_geojson(table_name, inspection, output_path, upload_to_s3=False)
-    assert result is not None
+    geojson, result = await _geojson_from_columns(
+        db,
+        columns=other_columns | geo_columns,
+        table_name="test_geojson_from_db",
+    )
     geojson_size, geojson_url = result
     assert geojson_url is None
     assert geojson_size > 0
-
-    with open(output_path) as f:
-        geojson = json.load(f)
 
     assert geojson["type"] == "FeatureCollection"
     assert len(geojson["features"]) == 5
@@ -79,147 +113,61 @@ async def test_db_to_geojson(db, geo_columns, clean_db):
         for geo_col in geo_columns:
             assert geo_col not in feat["properties"]
 
-    output_path.unlink()
-    await db.execute(f'DROP TABLE IF EXISTS "{table_name}"')
-
 
 async def test_db_to_geojson_with_reserved_column(db, clean_db):
     """A CSV with a reserved PG column name (xmin) should still produce valid GeoJSON from DB."""
-    output_path = Path(f"{RESOURCE_ID}.geojson")
-    try:
-        output_path.unlink()
-    except FileNotFoundError:
-        pass
-
-    sep = ";"
-    columns = {
-        "xmin": range(1, 6),
-        "lat": [10.0 * k * (-1) ** k for k in range(1, 6)],
-        "long": [20.0 * k * (-1) ** k for k in range(1, 6)],
-    }
-    file = sep.join(columns) + "\n"
-    for i in range(5):
-        file += sep.join(str(val) for val in [data[i] for data in columns.values()]) + "\n"
-
-    with NamedTemporaryFile(delete=False) as fp:
-        fp.write(file.encode("utf-8"))
-        fp.seek(0)
-        inspection = csv_detective_routine(
-            file_path=fp.name,
-            output_profile=True,
-            num_rows=-1,
-            save_results=False,
-        )
-
-    table_name = "test_geojson_reserved_col"
-    await csv_to_db(fp.name, inspection, table_name)
-
-    result = await db_to_geojson(table_name, inspection, output_path, upload_to_s3=False)
-    assert result is not None
-    geojson_size, _ = result
-
-    with open(output_path) as f:
-        geojson = json.load(f)
+    geojson, _ = await _geojson_from_columns(
+        db,
+        columns={
+            "xmin": range(1, 6),
+            "lat": [10.0 * k * (-1) ** k for k in range(1, 6)],
+            "long": [20.0 * k * (-1) ** k for k in range(1, 6)],
+        },
+        table_name="test_geojson_reserved_col",
+    )
 
     assert len(geojson["features"]) == 5
     expected_xmin_values = list(range(1, 6))
     actual_xmin_values = [feat["properties"]["xmin"] for feat in geojson["features"]]
     assert actual_xmin_values == expected_xmin_values
 
-    output_path.unlink()
-    await db.execute(f'DROP TABLE IF EXISTS "{table_name}"')
-
 
 async def test_db_to_geojson_with_quote_in_column_name(db, clean_db):
     """A CSV with a single quote in a column name should not break the SQL query."""
-    output_path = Path(f"{RESOURCE_ID}.geojson")
-    try:
-        output_path.unlink()
-    except FileNotFoundError:
-        pass
-
-    sep = ";"
-    columns = {
-        "l'adresse": [
-            "10 rue de la Paix",
-            "5 avenue Foch",
-            "3 bd Raspail",
-            "1 place Vendôme",
-            "8 rue Rivoli",
-        ],
-        "lat": [10.0 * k * (-1) ** k for k in range(1, 6)],
-        "long": [20.0 * k * (-1) ** k for k in range(1, 6)],
-    }
-    file = sep.join(columns) + "\n"
-    for i in range(5):
-        file += sep.join(str(val) for val in [data[i] for data in columns.values()]) + "\n"
-
-    with NamedTemporaryFile(delete=False) as fp:
-        fp.write(file.encode("utf-8"))
-        fp.seek(0)
-        inspection = csv_detective_routine(
-            file_path=fp.name,
-            output_profile=True,
-            num_rows=-1,
-            save_results=False,
-        )
-
-    table_name = "test_geojson_quote_col"
-    await csv_to_db(fp.name, inspection, table_name)
-
-    result = await db_to_geojson(table_name, inspection, output_path, upload_to_s3=False)
-    assert result is not None
-
-    with open(output_path) as f:
-        geojson = json.load(f)
+    geojson, _ = await _geojson_from_columns(
+        db,
+        columns={
+            "l'adresse": [
+                "10 rue de la Paix",
+                "5 avenue Foch",
+                "3 bd Raspail",
+                "1 place Vendôme",
+                "8 rue Rivoli",
+            ],
+            "lat": [10.0 * k * (-1) ** k for k in range(1, 6)],
+            "long": [20.0 * k * (-1) ** k for k in range(1, 6)],
+        },
+        table_name="test_geojson_quote_col",
+    )
 
     assert len(geojson["features"]) == 5
     for feat in geojson["features"]:
         assert "l'adresse" in feat["properties"]
 
-    output_path.unlink()
-    await db.execute(f'DROP TABLE IF EXISTS "{table_name}"')
-
 
 async def test_db_to_geojson_lonlat(db, clean_db):
     """lonlat format ("[lon, lat]") should produce correct GeoJSON coordinates [lon, lat]."""
-    output_path = Path(f"{RESOURCE_ID}.geojson")
-    try:
-        output_path.unlink()
-    except FileNotFoundError:
-        pass
-
     lons = [20.0 * k * (-1) ** k for k in range(1, 6)]
     lats = [10.0 * k * (-1) ** k for k in range(1, 6)]
-    sep = ";"
-    columns = {
-        "nombre": range(1, 6),
-        "geopoint": [f"[{lon}, {lat}]" for lon, lat in zip(lons, lats)],
-    }
-    file = sep.join(columns) + "\n"
-    for i in range(5):
-        file += sep.join(str(val) for val in [data[i] for data in columns.values()]) + "\n"
-
-    with NamedTemporaryFile(delete=False) as fp:
-        fp.write(file.encode("utf-8"))
-        fp.seek(0)
-        inspection = csv_detective_routine(
-            file_path=fp.name,
-            output_profile=True,
-            num_rows=-1,
-            save_results=False,
-        )
-
-    assert "lonlat" in inspection["columns"]["geopoint"]["format"]
-
-    table_name = "test_geojson_lonlat"
-    await csv_to_db(fp.name, inspection, table_name)
-
-    result = await db_to_geojson(table_name, inspection, output_path, upload_to_s3=False)
-    assert result is not None
-
-    with open(output_path) as f:
-        geojson = json.load(f)
+    geojson, _ = await _geojson_from_columns(
+        db,
+        columns={
+            "nombre": range(1, 6),
+            "geopoint": [f"[{lon}, {lat}]" for lon, lat in zip(lons, lats)],
+        },
+        table_name="test_geojson_lonlat",
+        inspection_check=_assert_lonlat_format,
+    )
 
     assert len(geojson["features"]) == 5
     for i, feat in enumerate(geojson["features"]):
@@ -229,51 +177,22 @@ async def test_db_to_geojson_lonlat(db, clean_db):
         assert "geopoint" not in feat["properties"]
         assert "nombre" in feat["properties"]
 
-    output_path.unlink()
-    await db.execute(f'DROP TABLE IF EXISTS "{table_name}"')
-
 
 async def test_db_to_geojson_geojson_column(db, clean_db):
     """A column containing GeoJSON strings should produce valid geometry from DB."""
-    output_path = Path(f"{RESOURCE_ID}.geojson")
-    try:
-        output_path.unlink()
-    except FileNotFoundError:
-        pass
-
     geometries = [
         {"type": "Point", "coordinates": [10 * k * (-1) ** k, 20 * k * (-1) ** k]}
         for k in range(1, 6)
     ]
-    sep = ";"
-    columns = {
-        "nombre": range(1, 6),
-        "polyg": [json.dumps(g) for g in geometries],
-    }
-    file = sep.join(columns) + "\n"
-    for i in range(5):
-        file += sep.join(str(val) for val in [data[i] for data in columns.values()]) + "\n"
-
-    with NamedTemporaryFile(delete=False) as fp:
-        fp.write(file.encode("utf-8"))
-        fp.seek(0)
-        inspection = csv_detective_routine(
-            file_path=fp.name,
-            output_profile=True,
-            num_rows=-1,
-            save_results=False,
-        )
-
-    assert "geojson" in inspection["columns"]["polyg"]["format"]
-
-    table_name = "test_geojson_geojson_col"
-    await csv_to_db(fp.name, inspection, table_name)
-
-    result = await db_to_geojson(table_name, inspection, output_path, upload_to_s3=False)
-    assert result is not None
-
-    with open(output_path) as f:
-        geojson = json.load(f)
+    geojson, _ = await _geojson_from_columns(
+        db,
+        columns={
+            "nombre": range(1, 6),
+            "polyg": [json.dumps(g) for g in geometries],
+        },
+        table_name="test_geojson_geojson_col",
+        inspection_check=_assert_geojson_column_format,
+    )
 
     assert len(geojson["features"]) == 5
     for i, feat in enumerate(geojson["features"]):
@@ -281,44 +200,17 @@ async def test_db_to_geojson_geojson_column(db, clean_db):
         assert "polyg" not in feat["properties"]
         assert "nombre" in feat["properties"]
 
-    output_path.unlink()
-    await db.execute(f'DROP TABLE IF EXISTS "{table_name}"')
-
 
 async def test_db_to_geojson_many_columns(db, clean_db):
     """More than 50 property columns should trigger json_build_object chunking."""
-    output_path = Path(f"{RESOURCE_ID}.geojson")
-    try:
-        output_path.unlink()
-    except FileNotFoundError:
-        pass
-
-    sep = ";"
     columns = {f"col_{i:03d}": range(1, 6) for i in range(55)}
     columns["lat"] = [10.0 * k * (-1) ** k for k in range(1, 6)]
     columns["long"] = [20.0 * k * (-1) ** k for k in range(1, 6)]
-    file = sep.join(columns) + "\n"
-    for i in range(5):
-        file += sep.join(str(val) for val in [data[i] for data in columns.values()]) + "\n"
-
-    with NamedTemporaryFile(delete=False) as fp:
-        fp.write(file.encode("utf-8"))
-        fp.seek(0)
-        inspection = csv_detective_routine(
-            file_path=fp.name,
-            output_profile=True,
-            num_rows=-1,
-            save_results=False,
-        )
-
-    table_name = "test_geojson_many_cols"
-    await csv_to_db(fp.name, inspection, table_name)
-
-    result = await db_to_geojson(table_name, inspection, output_path, upload_to_s3=False)
-    assert result is not None
-
-    with open(output_path) as f:
-        geojson = json.load(f)
+    geojson, _ = await _geojson_from_columns(
+        db,
+        columns=columns,
+        table_name="test_geojson_many_cols",
+    )
 
     assert len(geojson["features"]) == 5
     feat = geojson["features"][0]
@@ -326,6 +218,3 @@ async def test_db_to_geojson_many_columns(db, clean_db):
         assert f"col_{i:03d}" in feat["properties"]
     assert "lat" not in feat["properties"]
     assert "long" not in feat["properties"]
-
-    output_path.unlink()
-    await db.execute(f'DROP TABLE IF EXISTS "{table_name}"')

--- a/tests/test_crawl/test_backoff.py
+++ b/tests/test_crawl/test_backoff.py
@@ -12,11 +12,6 @@ from udata_hydra.crawl.check_resources import (
     check_resource,
 )
 
-# TODO: make file content configurable
-SIMPLE_CSV_CONTENT = """code_insee,number
-95211,102
-36522,48"""
-
 pytestmark = pytest.mark.asyncio
 # allows nested async to test async with async :mindblown:
 nest_asyncio.apply()

--- a/tests/test_crawl/test_crawl.py
+++ b/tests/test_crawl/test_crawl.py
@@ -264,7 +264,7 @@ async def test_no_switch_head_to_get(setup_catalog, rmock, produce_mock, analysi
 
 async def test_analyse_resource(setup_catalog, mocker, fake_check):
     mocker.patch("udata_hydra.analysis.resource.download_resource", mock_download_resource)
-    # disable webhook, tested in following test
+    # webhook covered by test_analyse_resource_udata_webhook
     mocker.patch("udata_hydra.config.WEBHOOK_ENABLED", False)
 
     check = await fake_check()
@@ -277,35 +277,27 @@ async def test_analyse_resource(setup_catalog, mocker, fake_check):
     assert result["mime_type"] == "text/plain"
 
 
-async def test_analyse_resource_send_udata(setup_catalog, mocker, rmock, fake_check, udata_url):
-    mocker.patch("udata_hydra.analysis.resource.download_resource", mock_download_resource)
-    rmock.put(udata_url, status=200, repeat=True)
-
-    check = await fake_check()
-    await analyse_resource(check=check, last_check=None)
-
-    req = rmock.requests[("PUT", URL(udata_url))]
-    assert len(req) == 1
-    document = req[0].kwargs["json"]
-    assert document["analysis:content-length"] == len(SIMPLE_CSV_CONTENT)
-    assert document["analysis:mime-type"] == "text/plain"
-
-
-async def test_analyse_resource_send_udata_no_change(
-    setup_catalog, mocker, rmock, fake_check, udata_url
+@pytest.mark.parametrize(
+    "same_checksum,expect_put",
+    [(False, True), (True, False)],
+    ids=["checksum_changed", "checksum_unchanged"],
+)
+async def test_analyse_resource_udata_webhook(
+    setup_catalog, mocker, rmock, fake_check, udata_url, same_checksum, expect_put
 ):
     mocker.patch("udata_hydra.analysis.resource.download_resource", mock_download_resource)
     rmock.put(udata_url, status=200, repeat=True)
-
-    # previous check with same checksum
-    last_check = await fake_check(
-        checksum=hashlib.sha1(SIMPLE_CSV_CONTENT.encode("utf-8")).hexdigest()
-    )
+    checksum = hashlib.sha1(SIMPLE_CSV_CONTENT.encode("utf-8")).hexdigest()
+    last_check = await fake_check(checksum=checksum) if same_checksum else None
     check = await fake_check()
     await analyse_resource(check=check, last_check=last_check)
-
-    # udata has not been called
-    assert ("PUT", URL(udata_url)) not in rmock.requests
+    put_key = ("PUT", URL(udata_url))
+    if expect_put:
+        doc = rmock.requests[put_key][0].kwargs["json"]
+        assert doc["analysis:content-length"] == len(SIMPLE_CSV_CONTENT)
+        assert doc["analysis:mime-type"] == "text/plain"
+    else:
+        assert put_key not in rmock.requests
 
 
 async def test_analyse_resource_from_crawl(setup_catalog, rmock, db, udata_url):

--- a/tests/test_crawl/test_crawl.py
+++ b/tests/test_crawl/test_crawl.py
@@ -446,46 +446,53 @@ async def test_no_change_analysis_harvested(
     assert res[0]["detected_last_modified_at"] == last_modfied_at
 
 
-async def test_change_analysis_last_modified_header_twice(
-    setup_catalog, rmock, fake_check, udata_url
+@pytest.mark.parametrize(
+    "head_last_modified,expect_put,expected_modified_at,use_detected_at",
+    [
+        ("Thu, 09 Jan 2020 09:33:37 GMT", False, None, False),
+        ("2020-01-09T09:33:37+04:00", True, "2020-01-09T09:33:37+04:00", True),
+    ],
+    ids=["same_instant_rfc822", "same_instant_different_offset"],
+)
+async def test_change_analysis_last_modified_no_reanalysis(
+    setup_catalog,
+    rmock,
+    fake_check,
+    udata_url,
+    head_last_modified,
+    expect_put,
+    expected_modified_at,
+    use_detected_at,
 ):
-    _date = "Thu, 09 Jan 2020 09:33:37 GMT"
-    await fake_check(
-        headers={"last-modified": _date, "content-type": "application/json"},
-        created_at=datetime.now() - timedelta(days=10),
-    )
+    created_at = datetime.now() - timedelta(days=10)
+    json_headers = {"content-type": "application/json"}
+    if use_detected_at:
+        await fake_check(
+            detected_last_modified_at=datetime.fromisoformat("2020-01-09T09:33:37+01:00"),
+            created_at=created_at,
+            headers=json_headers,
+        )
+    else:
+        await fake_check(
+            headers=json_headers | {"last-modified": head_last_modified},
+            created_at=created_at,
+        )
     rmock.head(
         RESOURCE_URL,
-        headers={"last-modified": _date, "content-type": "application/json"},
+        headers=json_headers | {"last-modified": head_last_modified},
     )
     rmock.get(RESOURCE_URL)
     rmock.put(udata_url, repeat=True)
     await start_checks(iterations=1)
-    # udata has not been called: not first check, outdated check, and last-modified stayed the same
-    assert ("PUT", URL(udata_url)) not in rmock.requests
-
-
-async def test_change_analysis_last_modified_header_twice_tz(
-    setup_catalog, rmock, fake_check, udata_url
-):
-    _date_1 = "2020-01-09T09:33:37+01:00"
-    _date_2 = "2020-01-09T09:33:37+04:00"
-    await fake_check(
-        detected_last_modified_at=datetime.fromisoformat(_date_1),
-        created_at=datetime.now() - timedelta(days=10),
-        headers={"content-type": "application/json"},
-    )
-    rmock.head(
-        RESOURCE_URL,
-        headers={"last-modified": _date_2, "content-type": "application/json"},
-    )
-    rmock.get(RESOURCE_URL)
-    rmock.put(udata_url, repeat=True)
-    await start_checks(iterations=1)
-    # udata has been called: last-modified has changed (different timezones)
-    assert ("PUT", URL(udata_url)) in rmock.requests
-    webhook = rmock.requests[("PUT", URL(udata_url))][0].kwargs["json"]
-    assert webhook.get("analysis:last-modified-at") == _date_2
+    put_key = ("PUT", URL(udata_url))
+    if expect_put:
+        assert put_key in rmock.requests
+        assert (
+            rmock.requests[put_key][0].kwargs["json"].get("analysis:last-modified-at")
+            == expected_modified_at
+        )
+    else:
+        assert put_key not in rmock.requests
 
 
 @pytest.mark.parametrize(

--- a/tests/test_crawl/test_crawl.py
+++ b/tests/test_crawl/test_crawl.py
@@ -496,25 +496,59 @@ async def test_change_analysis_last_modified_header_twice_tz(
     assert webhook.get("analysis:last-modified-at") == _date_2
 
 
-async def test_check_changed_content_length_header(setup_catalog, rmock, fake_check, udata_url):
+@pytest.mark.parametrize(
+    "header_name, head_header_value, expected_webhook_value",
+    [
+        pytest.param("content-length", "15", 15, id="content_length_changed"),
+        pytest.param("content-type", "text/csv", "text/csv", id="content_type_changed"),
+    ],
+)
+async def test_check_changed_header(
+    setup_catalog,
+    rmock,
+    fake_check,
+    udata_url,
+    header_name,
+    head_header_value,
+    expected_webhook_value,
+):
     await fake_check(
         created_at=datetime.now() - timedelta(days=10),
         headers={"content-type": "application/json", "content-length": "10"},
     )
     rmock.head(
         RESOURCE_URL,
-        headers={"content-length": "15", "content-type": "application/json"},
+        headers={
+            header_name: head_header_value,
+            "content-length": "10" if header_name != "content-length" else head_header_value,
+            "content-type": "application/json"
+            if header_name != "content-type"
+            else head_header_value,
+        },
     )
     rmock.get(RESOURCE_URL)
     rmock.put(udata_url, repeat=True)
     await start_checks(iterations=1)
-    # udata has been called in compute_check_has_changed: content-length has changed
     assert ("PUT", URL(udata_url)) in rmock.requests
     webhook = rmock.requests[("PUT", URL(udata_url))][0].kwargs["json"]
-    assert webhook.get("check:headers:content-length") == 15
+    assert webhook.get(f"check:headers:{header_name}") == expected_webhook_value
 
 
-async def test_no_check_changed_content_length_header(setup_catalog, rmock, fake_check, udata_url):
+@pytest.mark.parametrize(
+    "header_name, head_header_value",
+    [
+        pytest.param("content-length", "10", id="content_length_unchanged"),
+        pytest.param("content-type", "application/json", id="content_type_unchanged"),
+    ],
+)
+async def test_no_check_changed_header(
+    setup_catalog,
+    rmock,
+    fake_check,
+    udata_url,
+    header_name,
+    head_header_value,
+):
     await fake_check(
         created_at=datetime.now() - timedelta(days=10),
         headers={"content-type": "application/json", "content-length": "10"},
@@ -522,47 +556,17 @@ async def test_no_check_changed_content_length_header(setup_catalog, rmock, fake
     )
     rmock.head(
         RESOURCE_URL,
-        headers={"content-length": "10", "content-type": "application/json"},
+        headers={
+            header_name: head_header_value,
+            "content-length": "10" if header_name != "content-length" else head_header_value,
+            "content-type": "application/json"
+            if header_name != "content-type"
+            else head_header_value,
+        },
     )
     rmock.get(RESOURCE_URL)
     rmock.put(udata_url, repeat=True)
     await start_checks(iterations=1)
-    # udata has not been called: not first check, outdated check, and content-length stayed the same
-    assert ("PUT", URL(udata_url)) not in rmock.requests
-
-
-async def test_check_changed_content_type_header(setup_catalog, rmock, fake_check, udata_url):
-    await fake_check(
-        created_at=datetime.now() - timedelta(days=10),
-        headers={"content-type": "application/json", "content-length": "10"},
-    )
-    rmock.head(
-        RESOURCE_URL,
-        headers={"content-length": "10", "content-type": "text/csv"},
-    )
-    rmock.get(RESOURCE_URL)
-    rmock.put(udata_url, repeat=True)
-    await start_checks(iterations=1)
-    # udata has been called in compute_check_has_changed: content-type has changed
-    assert ("PUT", URL(udata_url)) in rmock.requests
-    webhook = rmock.requests[("PUT", URL(udata_url))][0].kwargs["json"]
-    assert webhook.get("check:headers:content-type") == "text/csv"
-
-
-async def test_no_check_changed_content_type_header(setup_catalog, rmock, fake_check, udata_url):
-    await fake_check(
-        created_at=datetime.now() - timedelta(days=10),
-        headers={"content-type": "application/json", "content-length": "10"},
-        detected_last_modified_at=datetime.now() - timedelta(days=20),
-    )
-    rmock.head(
-        RESOURCE_URL,
-        headers={"content-length": "10", "content-type": "application/json"},
-    )
-    rmock.get(RESOURCE_URL)
-    rmock.put(udata_url, repeat=True)
-    await start_checks(iterations=1)
-    # udata has not been called: not first check, outdated check, and content-type remained the same
     assert ("PUT", URL(udata_url)) not in rmock.requests
 
 

--- a/tests/test_crawl/test_crawl.py
+++ b/tests/test_crawl/test_crawl.py
@@ -14,7 +14,7 @@ from aioresponses import CallbackResult
 from asyncpg import Record
 from yarl import URL
 
-from tests.conftest import RESOURCE_ID, RESOURCE_URL
+from tests.conftest import RESOURCE_ID, RESOURCE_URL, SIMPLE_CSV_CONTENT
 from udata_hydra import config
 from udata_hydra.analysis.resource import analyse_resource
 from udata_hydra.crawl import start_checks
@@ -22,11 +22,6 @@ from udata_hydra.crawl.check_resources import check_resource
 from udata_hydra.crawl.preprocess_check_data import get_content_type_from_header
 from udata_hydra.db.check import Check
 from udata_hydra.db.resource import Resource
-
-# TODO: make file content configurable
-SIMPLE_CSV_CONTENT = """code_insee,number
-95211,102
-36522,48"""
 
 pytestmark = pytest.mark.asyncio
 # allows nested async to test async with async :mindblown:

--- a/tests/test_crawl/test_crawl.py
+++ b/tests/test_crawl/test_crawl.py
@@ -235,18 +235,19 @@ async def test_deleted_check(setup_catalog, rmock, fake_check, produce_mock):
     assert ("HEAD", URL(rurl)) in rmock.requests
 
 
-async def test_switch_head_to_get(setup_catalog, rmock, produce_mock):
+@pytest.mark.parametrize(
+    "head_status,head_headers",
+    [
+        pytest.param(501, None, id="invalid_status"),
+        pytest.param(200, {}, id="missing_size_headers"),
+    ],
+)
+async def test_switch_head_to_get(setup_catalog, rmock, produce_mock, head_status, head_headers):
     rurl = RESOURCE_URL
-    rmock.head(rurl, status=501)
-    rmock.get(rurl, status=200)
-    await start_checks(iterations=1)
-    assert ("HEAD", URL(rurl)) in rmock.requests
-    assert ("GET", URL(rurl)) in rmock.requests
-
-
-async def test_switch_head_to_get_headers(setup_catalog, rmock, produce_mock):
-    rurl = RESOURCE_URL
-    rmock.head(rurl, status=200, headers={})
+    head_kwargs = {"status": head_status}
+    if head_headers is not None:
+        head_kwargs["headers"] = head_headers
+    rmock.head(rurl, **head_kwargs)
     rmock.get(rurl, status=200)
     await start_checks(iterations=1)
     assert ("HEAD", URL(rurl)) in rmock.requests

--- a/tests/test_db/test_db_resources.py
+++ b/tests/test_db/test_db_resources.py
@@ -11,20 +11,17 @@ pytestmark = pytest.mark.asyncio
 nest_asyncio.apply()
 
 
-async def test_catalog(setup_catalog, db):
+async def test_catalog_deleted(setup_catalog, db, rmock):
     res = await db.fetch(
         "SELECT * FROM catalog WHERE resource_id = $1",
         RESOURCE_ID,
     )
     # Only one resource because the other belonged to an archived dataset
     assert len(res) == 1
-    resource = res[0]
-    assert resource["url"] == RESOURCE_URL
-    assert resource["dataset_id"] == DATASET_ID
-    assert resource["status"] is None
+    assert res[0]["url"] == RESOURCE_URL
+    assert res[0]["dataset_id"] == DATASET_ID
+    assert res[0]["status"] is None
 
-
-async def test_catalog_deleted(setup_catalog, db, rmock):
     res = await db.fetch("SELECT id FROM catalog WHERE deleted = FALSE")
     assert len(res) == 1
     with open("tests/data/catalog.csv", "rb") as cfile:


### PR DESCRIPTION
Refactoring/cleaning only for tests, using parametrization, deduplication, consolidation and fixtures.
Does not affect test coverage at all.

Refactors (sorry for putting them all in the same PR!):

- Deduplicate csv and crawl switch tests (https://github.com/datagouv/hydra/commit/5848343)
- Consolidate parquet export, crawl header, and catalog tests (https://github.com/datagouv/hydra/commit/21c5602)
- Parametrize analyse_resource udata webhook cases (https://github.com/datagouv/hydra/commit/f1f95dc)
- Parametrize last-modified no-reanalysis cases (https://github.com/datagouv/hydra/commit/281ed38)
- Consolidate malformed auth checks in test_create_resource (https://github.com/datagouv/hydra/commit/9e4ccf9)
- Add csv_table_for_purge fixture for purge CLI tests (https://github.com/datagouv/hydra/commit/ac1bb09)
- Refactor `test_conversion/test_db_to_geojson.py` using a common geojson pipeline helper (https://github.com/datagouv/hydra/commit/adda33b)
- Refactor `test_api/test_api_resources.py` using a fixture: `test_update_resource` and `test_update_resource_url_since_load_catalog use the fixture`; removed duplicate payload dict and unused datetime import. (https://github.com/datagouv/hydra/commit/eec0dab)
- Move shared `SIMPLE_CSV_CONTENT` to conftest (https://github.com/datagouv/hydra/commit/178b69f)
