### PR TITLE
fix(cli): make fd var bound (initialize to None)

### DIFF
--- a/udata_hydra/cli/catalog.py
+++ b/udata_hydra/cli/catalog.py
@@ -42,6 +42,7 @@ async def _load_catalog(
                 for row in bar.iter(rows):
                     yield row
 
+        fd = None
         try:
             log.info(f"Downloading resources catalog from {url}...")
             with NamedTemporaryFile(
@@ -94,8 +95,9 @@ async def _load_catalog(
         except Exception as e:
             raise e
         finally:
-            fd.close()
-            os.unlink(fd.name)
+            if fd:
+                fd.close()
+                os.unlink(fd.name)
 
 
 @cli.command()


### PR DESCRIPTION
Currently, our crons fail with
```
UnboundLocalError: cannot access local variable 'fd' where it is not associated 
with a value
```

The underlying error may be related to the temporary file creation.