### PR TITLE
refactor: all temporary files path consistent, including fallback, th…

### DIFF
--- a/tests/test_utils/test_file.py
+++ b/tests/test_utils/test_file.py
@@ -1,5 +1,6 @@
 import gzip
 import os
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -13,15 +14,31 @@ from udata_hydra.utils.file import (
 )
 
 
-def test_remove_remainders_cleans_temporary_folder(mocker, tmp_path):
-    mocker.patch("udata_hydra.config.TEMPORARY_DOWNLOAD_FOLDER", str(tmp_path))
+@pytest.mark.parametrize(
+    "temp_config",
+    (
+        pytest.param("configured", id="configured"),
+        pytest.param("", id="system-temp"),
+    ),
+)
+def test_remove_remainders_cleans_temporary_folder(mocker, tmp_path, temp_config):
+    if temp_config == "configured":
+        mocker.patch("udata_hydra.config.TEMPORARY_DOWNLOAD_FOLDER", str(tmp_path))
+        expected_parent = tmp_path
+    else:
+        mocker.patch("udata_hydra.config.TEMPORARY_DOWNLOAD_FOLDER", "")
+        expected_parent = Path(tempfile.gettempdir())
+
     resource_id = "deadbeef"
-    leftover = temporary_folder() / f"{resource_id}.parquet"
+    leftover = expected_parent / f"{resource_id}.parquet"
     leftover.write_text("leftover")
 
-    remove_remainders(resource_id, ["parquet"])
-
-    assert not leftover.exists()
+    try:
+        remove_remainders(resource_id, ["parquet"])
+        assert not leftover.exists()
+        assert temporary_folder() == expected_parent
+    finally:
+        leftover.unlink(missing_ok=True)
 
 
 def test_remove_remainders_ignores_cwd(mocker, tmp_path):

--- a/tests/test_utils/test_file.py
+++ b/tests/test_utils/test_file.py
@@ -1,0 +1,61 @@
+import gzip
+import os
+from pathlib import Path
+
+import pytest
+
+from udata_hydra.utils import IOException
+from udata_hydra.utils.file import (
+    download_resource,
+    extract_gzip,
+    remove_remainders,
+    temporary_folder,
+)
+
+
+def test_remove_remainders_cleans_temporary_folder(mocker, tmp_path):
+    mocker.patch("udata_hydra.config.TEMPORARY_DOWNLOAD_FOLDER", str(tmp_path))
+    resource_id = "deadbeef"
+    leftover = temporary_folder() / f"{resource_id}.parquet"
+    leftover.write_text("leftover")
+
+    remove_remainders(resource_id, ["parquet"])
+
+    assert not leftover.exists()
+
+
+def test_remove_remainders_ignores_cwd(mocker, tmp_path):
+    mocker.patch("udata_hydra.config.TEMPORARY_DOWNLOAD_FOLDER", str(tmp_path))
+    cwd_file = Path("orphan.parquet")
+    cwd_file.write_text("keep me")
+
+    try:
+        remove_remainders("orphan", ["parquet"])
+        assert cwd_file.exists()
+    finally:
+        cwd_file.unlink(missing_ok=True)
+
+
+def test_extract_gzip_writes_to_temporary_folder(mocker, tmp_path):
+    mocker.patch("udata_hydra.config.TEMPORARY_DOWNLOAD_FOLDER", str(tmp_path))
+    gz_path = tmp_path / "data.csv.gz"
+    with gzip.open(gz_path, "wb") as gz_file:
+        gz_file.write(b"col\nval")
+
+    extracted = extract_gzip(str(gz_path))
+
+    try:
+        assert Path(extracted.name).parent == tmp_path
+        with open(extracted.name, "rb") as f:
+            assert f.read() == b"col\nval"
+    finally:
+        os.remove(extracted.name)
+
+
+async def test_download_resource_rejects_oversized_content_length():
+    with pytest.raises(IOException, match="File too large to download"):
+        await download_resource(
+            url="http://example.com/file.csv",
+            headers={"content-length": "1000"},
+            max_size_allowed=500,
+        )

--- a/udata_hydra/analysis/geojson.py
+++ b/udata_hydra/analysis/geojson.py
@@ -18,6 +18,7 @@ from udata_hydra.utils import (
     handle_parse_exception,
     remove_remainders,
 )
+from udata_hydra.utils.file import temporary_folder
 
 # Re-exported so that `udata_hydra.analysis.geojson.geojson_to_pmtiles` keeps
 # working as a `mock.patch` target for tests that mock the call site used by
@@ -62,7 +63,7 @@ async def analyse_geojson(
 
         # Convert to PMTiles
         try:
-            pmtiles_filepath = Path(f"{resource_id}.pmtiles")
+            pmtiles_filepath = temporary_folder() / f"{resource_id}.pmtiles"
             pmtiles_size, pmtiles_url = await geojson_to_pmtiles(
                 input_file_path=Path(tmp_file.name),
                 output_file_path=pmtiles_filepath,

--- a/udata_hydra/analysis/helpers.py
+++ b/udata_hydra/analysis/helpers.py
@@ -1,11 +1,11 @@
 import json
-import os
 from typing import IO
 
 from asyncpg import Record
 
 from udata_hydra import config
 from udata_hydra.utils import IOException, UdataPayload, download_resource, queue, send
+from udata_hydra.utils.file import temporary_folder
 
 
 def get_python_type(column: dict) -> str:
@@ -24,8 +24,7 @@ async def read_or_download_file(
     exception: Record | None,
 ) -> IO[bytes]:
     if filename:
-        temp_dir = config.TEMPORARY_DOWNLOAD_FOLDER or "/tmp"
-        full_path = os.path.join(temp_dir, filename)
+        full_path = temporary_folder() / filename
         try:
             return open(full_path, "rb")
         except FileNotFoundError:

--- a/udata_hydra/cli/catalog.py
+++ b/udata_hydra/cli/catalog.py
@@ -15,6 +15,7 @@ from udata_hydra.cli.db import _drop_dbs, _migrate
 from udata_hydra.db.resource import Resource
 from udata_hydra.logger import quiet_logs
 from udata_hydra.utils import download_file
+from udata_hydra.utils.file import temporary_folder
 
 
 async def _load_catalog(
@@ -45,9 +46,7 @@ async def _load_catalog(
         fd = None
         try:
             log.info(f"Downloading resources catalog from {url}...")
-            with NamedTemporaryFile(
-                dir=config.TEMPORARY_DOWNLOAD_FOLDER or None, delete=False
-            ) as fd:
+            with NamedTemporaryFile(dir=str(temporary_folder()), delete=False) as fd:
                 await download_file(url, fd)
             log.info("Upserting resources catalog in database...")
             # consider everything deleted, deleted will be updated when loading new catalog

--- a/udata_hydra/cli/crawl.py
+++ b/udata_hydra/cli/crawl.py
@@ -4,12 +4,12 @@ import aiohttp
 import asyncpg
 import typer
 
-from udata_hydra import config
 from udata_hydra.cli.common import _make_async_wrapper, cli, log
 from udata_hydra.crawl.check_resources import check_resource as crawl_check_resource
 from udata_hydra.crawl.check_resources import probe_cors
 from udata_hydra.db.resource import Resource
 from udata_hydra.utils import download_resource
+from udata_hydra.utils.file import temporary_folder
 
 
 async def _crawl_url(
@@ -52,9 +52,8 @@ async def _download_resource_cli(resource_id: str, output_dir: str | None = None
     try:
         tmp_file, file_extension = await download_resource(resource["url"])
         output_path = (
-            Path(output_dir or config.TEMPORARY_DOWNLOAD_FOLDER or ".")
-            / f"{resource_id}{file_extension}"
-        )
+            Path(output_dir) if output_dir else temporary_folder()
+        ) / f"{resource_id}{file_extension}"
         # Move the temporary file to the desired output location
         Path(tmp_file.name).rename(output_path)
         log.info(f"Successfully downloaded resource {resource_id} to {output_path}")

--- a/udata_hydra/conversion/db_to_geojson_and_pmtiles.py
+++ b/udata_hydra/conversion/db_to_geojson_and_pmtiles.py
@@ -7,6 +7,7 @@ from udata_hydra.conversion.geojson_to_pmtiles import geojson_to_pmtiles
 from udata_hydra.db.check import Check
 from udata_hydra.db.resource import Resource
 from udata_hydra.utils import Timer
+from udata_hydra.utils.file import temporary_folder
 
 DEFAULT_GEOJSON_FILEPATH = Path("converted_from_db.geojson")
 DEFAULT_PMTILES_FILEPATH = Path("converted_from_geojson.pmtiles")
@@ -26,8 +27,8 @@ async def db_to_geojson_and_pmtiles(
     )
 
     if resource_id:
-        geojson_filepath = Path(f"{resource_id}.geojson")
-        pmtiles_filepath = Path(f"{resource_id}.pmtiles")
+        geojson_filepath = temporary_folder() / f"{resource_id}.geojson"
+        pmtiles_filepath = temporary_folder() / f"{resource_id}.pmtiles"
         # Update resource status for GeoJSON conversion
         await Resource.update(resource_id, {"status": "CONVERTING_TO_GEOJSON"})
     else:

--- a/udata_hydra/conversion/db_to_parquet.py
+++ b/udata_hydra/conversion/db_to_parquet.py
@@ -3,6 +3,7 @@ import pyarrow.parquet as pq
 
 from udata_hydra.conversion.schema import PYTHON_TYPE_TO_PA
 from udata_hydra.db import db_col_name
+from udata_hydra.utils.file import temporary_folder
 
 BATCH_SIZE = 50_000
 
@@ -29,8 +30,8 @@ async def db_to_parquet(
         ]
     )
 
-    parquet_path = f"{output_filename}.parquet"
-    writer = pq.ParquetWriter(parquet_path, schema, compression="zstd") if output_filename else None
+    parquet_path = temporary_folder() / f"{output_filename}.parquet" if output_filename else None
+    writer = pq.ParquetWriter(parquet_path, schema, compression="zstd") if parquet_path else None
 
     try:
         async with pool.acquire() as conn:
@@ -51,6 +52,6 @@ async def db_to_parquet(
         if writer:
             writer.close()
 
-    if output_filename:
-        return parquet_path, pq.read_table(parquet_path)
-    return parquet_path, table
+    if parquet_path:
+        return str(parquet_path), pq.read_table(parquet_path)
+    return "", table

--- a/udata_hydra/utils/file.py
+++ b/udata_hydra/utils/file.py
@@ -5,6 +5,7 @@ import mimetypes
 import os
 import re
 import tempfile
+from pathlib import Path
 from typing import IO
 
 import aiohttp
@@ -14,6 +15,16 @@ from udata_hydra import config
 from udata_hydra.utils import IOException
 
 log = logging.getLogger("udata-hydra")
+
+
+def temporary_folder() -> Path:
+    """Return the configured folder for transient pipeline files."""
+    if config.TEMPORARY_DOWNLOAD_FOLDER:
+        folder = Path(config.TEMPORARY_DOWNLOAD_FOLDER)
+    else:
+        folder = Path(tempfile.gettempdir())
+    folder.mkdir(parents=True, exist_ok=True)
+    return folder
 
 
 def compute_checksum_from_file(filename: str) -> str:
@@ -30,7 +41,7 @@ def compute_checksum_from_file(filename: str) -> str:
 def extract_gzip(file_path: str) -> IO[bytes]:
     with gzip.open(file_path, "rb") as gz_file:
         with tempfile.NamedTemporaryFile(
-            dir=config.TEMPORARY_DOWNLOAD_FOLDER or None, mode="wb", delete=False
+            dir=str(temporary_folder()), mode="wb", delete=False
         ) as temp_file:
             temp_file.write(gz_file.read())
     return temp_file
@@ -53,9 +64,7 @@ async def download_resource(
     ):
         raise IOException("File too large to download", url=url)
 
-    tmp_file = tempfile.NamedTemporaryFile(
-        dir=config.TEMPORARY_DOWNLOAD_FOLDER or None, delete=False
-    )
+    tmp_file = tempfile.NamedTemporaryFile(dir=str(temporary_folder()), delete=False)
 
     chunk_size = 1024
     i = 0
@@ -124,5 +133,6 @@ async def download_file(url: str, fd):
 def remove_remainders(resource_id: str, extensions: list[str]) -> None:
     """Delete potential remainders from process that crashed"""
     for ext in extensions:
-        if os.path.exists(f"{resource_id}.{ext}"):
-            os.remove(f"{resource_id}.{ext}")
+        path = temporary_folder() / f"{resource_id}.{ext}"
+        if path.exists():
+            path.unlink()


### PR DESCRIPTION
Just a PR as a reminder for what could/should be done, but this can be done in another PR.

Following [this conversation](https://matrix.to/#/!JhYLlNfafzlYlPbPhk:agent.dinum.tchap.gouv.fr/$qWTfqtmtmoJaOW14IUbrhTrKPwikoh5cSwzm3m4m8Sw?via=agent.dinum.tchap.gouv.fr):

- All temporary files path consistent, including fallback, thanks to a new helper `temporary_folder()`
- Add unit tests for methods in `file.py`

EDIT: This PR is replaced by https://github.com/datagouv/hydra/pull/443 and https://github.com/datagouv/hydra/pull/449