### PR TITLE
test: add file.py unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "catalog_harvested: use catalog_harvested.csv as source",
 ]
-addopts = "--cov=udata_hydra --cov-report term-missing --cov-branch --cov-fail-under=83"
+addopts = "--cov=udata_hydra --cov-report term-missing --cov-branch --cov-fail-under=85"
 
 [tool.ty]
 [tool.ty.rules]

--- a/tests/test_utils/test_file.py
+++ b/tests/test_utils/test_file.py
@@ -1,0 +1,46 @@
+import gzip
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from udata_hydra.utils import IOException
+from udata_hydra.utils.file import download_resource, extract_gzip, storage_path
+
+
+@pytest.mark.parametrize("case", ("configured", "system-temp", "test-data"))
+def test_storage_path(mocker, tmp_path, case):
+    if case == "configured":
+        mocker.patch("udata_hydra.config.TEMPORARY_DOWNLOAD_FOLDER", str(tmp_path))
+        assert storage_path("file.csv") == tmp_path / "file.csv"
+        assert storage_path("") == tmp_path
+    elif case == "system-temp":
+        mocker.patch("udata_hydra.config.TEMPORARY_DOWNLOAD_FOLDER", "")
+        assert storage_path("file.csv").parent == Path(tempfile.gettempdir())
+    else:
+        assert storage_path("tests/data/foo.csv") == Path("tests/data/foo.csv")
+
+
+def test_extract_gzip_writes_to_storage_path(mocker, tmp_path):
+    mocker.patch("udata_hydra.config.TEMPORARY_DOWNLOAD_FOLDER", str(tmp_path))
+    gz_path = tmp_path / "data.csv.gz"
+    gz_path.write_bytes(gzip.compress(b"col\nval"))
+
+    extracted = extract_gzip(str(gz_path))
+
+    try:
+        assert Path(extracted.name).parent == storage_path("")
+        with open(extracted.name, "rb") as f:
+            assert f.read() == b"col\nval"
+    finally:
+        os.remove(extracted.name)
+
+
+async def test_download_resource_rejects_oversized_content_length():
+    with pytest.raises(IOException, match="File too large to download"):
+        await download_resource(
+            url="http://example.com/file.csv",
+            headers={"content-length": "1000"},
+            max_size_allowed=500,
+        )

--- a/tests/test_utils/test_file.py
+++ b/tests/test_utils/test_file.py
@@ -44,3 +44,11 @@ async def test_download_resource_rejects_oversized_content_length():
             headers={"content-length": "1000"},
             max_size_allowed=500,
         )
+
+
+async def test_download_resource_rejects_oversized_while_streaming(rmock):
+    url = "http://example.com/file.csv"
+    rmock.get(url, status=200, body=b"x" * 2048)
+
+    with pytest.raises(IOException, match="File too large to download"):
+        await download_resource(url=url, max_size_allowed=500)


### PR DESCRIPTION
Add unit tests for `file.py`.

Test coverage is up from 83,8% to 85.1%

Later on, once `remove_remainders` is adjusted, we can also maybe add an unit test for `remove_remainders` in this PR.