### PR TITLE
feat(db): add transaction for csv-to-db

### DIFF
--- a/tests/test_analysis/test_analysis_parquet.py
+++ b/tests/test_analysis/test_analysis_parquet.py
@@ -9,7 +9,9 @@ from unittest.mock import patch
 import pandas as pd
 import pyarrow.parquet as pq
 import pytest
+from slugify import slugify
 
+from udata_hydra import config
 from udata_hydra.analysis import helpers
 from udata_hydra.data_formats import Parquet
 from udata_hydra.utils import ParseException, storage_path
@@ -212,3 +214,48 @@ async def test_parquet_to_db_create_table_failure_raises_parse_exception(
     assert res[0]["val"] == "original-data"
 
     await db.execute(f'DROP TABLE IF EXISTS "{table_name}"')
+
+
+async def test_parquet_to_db_indexes_renamed(db, clean_db, fake_check):
+    """Indexes created with shadow table names are renamed to the real table name."""
+    check = await fake_check()
+    table_name = hashlib.md5(check["url"].encode("utf-8")).hexdigest()
+
+    df = pd.DataFrame(
+        {"name": ["Alice", "Bob"], "score": [100, 90], "category": ["Science", "Arts"]}
+    )
+    inspection = {
+        "columns": {
+            "name": {"python_type": "string", "format": set()},
+            "score": {"python_type": "int", "format": set()},
+            "category": {"python_type": "string", "format": set()},
+        },
+        "total_lines": 2,
+    }
+    table_indexes = {"name": "index", "category": "index"}
+    with NamedTemporaryFile(suffix=".parquet", dir=storage_path("")) as fp:
+        df.to_parquet(fp.name)
+        file = Parquet(file_name=os.path.basename(fp.name), inspection=inspection)
+        table = await file.to_db(check=check, table_indexes=table_indexes)
+
+    assert table.table_name == table_name
+
+    rows = await db.fetch(
+        "SELECT indexname FROM pg_indexes WHERE tablename = $1 AND schemaname = $2",
+        table_name,
+        config.DATABASE_SCHEMA,
+    )
+    index_names = [r["indexname"] for r in rows]
+
+    assert not any(name.startswith(f"{table_name}_s") for name in index_names), (
+        f"Index names still contain shadow suffix: {index_names}"
+    )
+
+    for col in ("name", "category"):
+        expected = f"{table_name}_{slugify(col)}_idx"
+        assert expected in index_names, f"Expected index {expected} not found in {index_names}"
+
+    res = list(await db.fetch(f'SELECT * FROM "{table_name}" ORDER BY name'))
+    assert len(res) == 2
+    assert res[0]["name"] == "Alice"
+    assert res[1]["name"] == "Bob"

--- a/tests/test_analysis/test_analysis_parquet.py
+++ b/tests/test_analysis/test_analysis_parquet.py
@@ -1,6 +1,9 @@
+import hashlib
 import io
 import json
+import os
 from datetime import datetime
+from tempfile import NamedTemporaryFile
 from unittest.mock import patch
 
 import pandas as pd
@@ -9,7 +12,7 @@ import pytest
 
 from udata_hydra.analysis import helpers
 from udata_hydra.data_formats import Parquet
-from udata_hydra.utils import ParseException
+from udata_hydra.utils import ParseException, storage_path
 
 pytestmark = pytest.mark.asyncio
 
@@ -136,51 +139,74 @@ async def test_parquet_to_db_rejects_too_long_column_name(fake_check):
     assert exc.value.step == "scan_column_names"
 
 
-async def test_parquet_to_db_copy_failure_raises_parse_exception(fake_check, mocker):
+async def test_parquet_to_db_copy_failure_raises_parse_exception(db, clean_db, fake_check, mocker):
     """Wrap PostgreSQL COPY failures in a ParseException for consistent error handling."""
     check = await fake_check()
-    mock_pool = mocker.MagicMock()
-    mock_pool.execute = mocker.AsyncMock()
-    mock_pool.copy_records_to_table = mocker.AsyncMock(
-        side_effect=RuntimeError("copy failed"),
-    )
+    table_name = hashlib.md5(check["url"].encode("utf-8")).hexdigest()
+
+    await db.execute(f'CREATE TABLE "{table_name}" (__id SERIAL PRIMARY KEY, val text)')
+    await db.execute(f"INSERT INTO \"{table_name}\" (val) VALUES ('original-data')")
+
+    def make_failing_iter(*args, **kwargs):
+        def _gen():
+            raise RuntimeError("simulated copy failure")
+            yield
+
+        return _gen()
+
     mocker.patch(
-        "udata_hydra.data_formats.parquet.to_db.context.pool",
-        new=mocker.AsyncMock(return_value=mock_pool),
+        "udata_hydra.data_formats.parquet.to_db._iter_parquet_rows",
+        make_failing_iter,
     )
-    mocker.patch("udata_hydra.data_formats.parquet.to_db.Resource.update", new=mocker.AsyncMock())
+
     inspection = {
         "columns": {"name": {"python_type": "string", "format": set()}},
         "total_lines": 1,
     }
-    with patch("udata_hydra.data_formats.data_format.os.path.getsize", return_value=10):
-        file = Parquet(file_name="file.parquet", inspection=inspection)
-    with pytest.raises(ParseException) as exc:
-        await file.to_db(check=check)
+    df = pd.DataFrame({"name": ["test"]})
+    with NamedTemporaryFile(suffix=".parquet", dir=storage_path("")) as fp:
+        df.to_parquet(fp.name)
+        file = Parquet(file_name=os.path.basename(fp.name), inspection=inspection)
+        with pytest.raises(ParseException) as exc:
+            await file.to_db(check=check)
+
     assert exc.value.step == "copy_records_to_table"
 
+    res = await db.fetch(f'SELECT * FROM "{table_name}"')
+    assert len(res) == 1
+    assert res[0]["val"] == "original-data"
 
-async def test_parquet_to_db_create_table_failure_raises_parse_exception(fake_check, mocker):
+    await db.execute(f'DROP TABLE IF EXISTS "{table_name}"')
+
+
+async def test_parquet_to_db_create_table_failure_raises_parse_exception(db, clean_db, fake_check, mocker):
     """Wrap CREATE TABLE failures in a ParseException for consistent error handling."""
     check = await fake_check()
-    mock_pool = mocker.MagicMock()
+    table_name = hashlib.md5(check["url"].encode("utf-8")).hexdigest()
 
-    async def execute(q: str, *args: object) -> None:
-        if "CREATE TABLE" in q.upper():
-            raise RuntimeError("ddl failed")
+    await db.execute(f'CREATE TABLE "{table_name}" (__id SERIAL PRIMARY KEY, val text)')
+    await db.execute(f"INSERT INTO \"{table_name}\" (val) VALUES ('original-data')")
 
-    mock_pool.execute = mocker.AsyncMock(side_effect=execute)
     mocker.patch(
-        "udata_hydra.data_formats.parquet.to_db.context.pool",
-        new=mocker.AsyncMock(return_value=mock_pool),
+        "udata_hydra.data_formats.parquet.to_db.compute_create_table_query",
+        return_value="NOT A VALID SQL STATEMENT",
     )
-    mocker.patch("udata_hydra.data_formats.parquet.to_db.Resource.update", new=mocker.AsyncMock())
+
     inspection = {
         "columns": {"name": {"python_type": "string", "format": set()}},
         "total_lines": 1,
     }
-    with patch("udata_hydra.data_formats.data_format.os.path.getsize", return_value=10):
-        file = Parquet(file_name="file.parquet", inspection=inspection)
-    with pytest.raises(ParseException) as exc:
-        await file.to_db(check=check)
+    df = pd.DataFrame({"name": ["test"]})
+    with NamedTemporaryFile(suffix=".parquet", dir=storage_path("")) as fp:
+        df.to_parquet(fp.name)
+        file = Parquet(file_name=os.path.basename(fp.name), inspection=inspection)
+        with pytest.raises(ParseException) as exc:
+            await file.to_db(check=check)
+
     assert exc.value.step == "create_table_query"
+
+    res = await db.fetch(f'SELECT * FROM "{table_name}"')
+    assert len(res) == 1
+    assert res[0]["val"] == "original-data"
+
+    await db.execute(f'DROP TABLE IF EXISTS "{table_name}"')

--- a/tests/test_analysis/test_analysis_parquet.py
+++ b/tests/test_analysis/test_analysis_parquet.py
@@ -179,7 +179,9 @@ async def test_parquet_to_db_copy_failure_raises_parse_exception(db, clean_db, f
     await db.execute(f'DROP TABLE IF EXISTS "{table_name}"')
 
 
-async def test_parquet_to_db_create_table_failure_raises_parse_exception(db, clean_db, fake_check, mocker):
+async def test_parquet_to_db_create_table_failure_raises_parse_exception(
+    db, clean_db, fake_check, mocker
+):
     """Wrap CREATE TABLE failures in a ParseException for consistent error handling."""
     check = await fake_check()
     table_name = hashlib.md5(check["url"].encode("utf-8")).hexdigest()

--- a/tests/test_conversion/test_csv_to_db.py
+++ b/tests/test_conversion/test_csv_to_db.py
@@ -142,8 +142,10 @@ async def test_csv_to_db_transaction_rollback_on_create_failure(db, clean_db, fa
         fp.seek(0)
         file = Csv(file_name=os.path.basename(fp.name), resource_id=RESOURCE_ID)
         await file.inspect()
-        with pytest.raises(ParseException):
+        with pytest.raises(ParseException) as exc:
             await file.to_db(check=check)
+
+        assert exc.value.step == "create_table_query"
 
     # Old table and data must survive the rollback
     res = await db.fetch(f'SELECT * FROM "{table_name}"')
@@ -180,8 +182,10 @@ async def test_csv_to_db_transaction_rollback_on_copy_failure(db, clean_db, fake
         fp.seek(0)
         file = Csv(file_name=os.path.basename(fp.name), resource_id=RESOURCE_ID)
         await file.inspect()
-        with pytest.raises(ParseException):
+        with pytest.raises(ParseException) as exc:
             await file.to_db(check=check)
+
+        assert exc.value.step == "copy_records_to_table"
 
     # Old table and data must survive the rollback
     res = await db.fetch(f'SELECT * FROM "{table_name}"')

--- a/tests/test_conversion/test_csv_to_db.py
+++ b/tests/test_conversion/test_csv_to_db.py
@@ -129,7 +129,7 @@ async def test_csv_to_db_transaction_rollback_on_create_failure(db, clean_db, fa
 
     # Simulate a previous successful import
     await db.execute(f'CREATE TABLE "{table_name}" (__id SERIAL PRIMARY KEY, val text)')
-    await db.execute(f'INSERT INTO "{table_name}" (val) VALUES (\'original-data\')')
+    await db.execute(f"INSERT INTO \"{table_name}\" (val) VALUES ('original-data')")
 
     # Make CREATE fail so the transaction rolls back the DROP
     mocker.patch(
@@ -160,13 +160,14 @@ async def test_csv_to_db_transaction_rollback_on_copy_failure(db, clean_db, fake
 
     # Simulate a previous successful import
     await db.execute(f'CREATE TABLE "{table_name}" (__id SERIAL PRIMARY KEY, val text)')
-    await db.execute(f'INSERT INTO "{table_name}" (val) VALUES (\'original-data\')')
+    await db.execute(f"INSERT INTO \"{table_name}\" (val) VALUES ('original-data')")
 
     # Make iter_tabular_rows return a generator that raises on iteration
     def make_failing_iter(*args, **kwargs):
         def _gen():
             raise RuntimeError("simulated copy failure")
             yield  # never reached
+
         return _gen()
 
     mocker.patch(

--- a/tests/test_conversion/test_csv_to_db.py
+++ b/tests/test_conversion/test_csv_to_db.py
@@ -5,8 +5,10 @@ from datetime import date, datetime, timedelta, timezone
 from tempfile import NamedTemporaryFile
 
 import pytest
+from slugify import slugify
 
 from tests.conftest import RESOURCE_ID
+from udata_hydra import config
 from udata_hydra.data_formats import Csv
 from udata_hydra.utils import ParseException, storage_path
 
@@ -123,7 +125,44 @@ async def test_reserved_column_name(db, clean_db, fake_check):
     assert res["xmin__hydra_renamed"] == "test"
 
 
+async def test_csv_to_db_indexes_renamed(db, clean_db, fake_check):
+    """Indexes created with shadow table names are renamed to the real table name."""
+    check = await fake_check()
+    table_name = hashlib.md5(check["url"].encode("utf-8")).hexdigest()
+
+    with NamedTemporaryFile(dir=storage_path("")) as fp:
+        fp.write(b"name,score,category\nAlice,100,Science\nBob,90,Arts\n")
+        fp.seek(0)
+        file = Csv(file_name=os.path.basename(fp.name), resource_id=RESOURCE_ID)
+        await file.inspect()
+        table_indexes = {"name": "index", "category": "index"}
+        table = await file.to_db(check=check, table_indexes=table_indexes)
+
+    assert table.table_name == table_name
+
+    rows = await db.fetch(
+        "SELECT indexname FROM pg_indexes WHERE tablename = $1 AND schemaname = $2",
+        table_name,
+        config.DATABASE_SCHEMA,
+    )
+    index_names = [r["indexname"] for r in rows]
+
+    assert not any(name.startswith(f"{table_name}_s") for name in index_names), (
+        f"Index names still contain shadow suffix: {index_names}"
+    )
+
+    for col in ("name", "category"):
+        expected = f"{table_name}_{slugify(col)}_idx"
+        assert expected in index_names, f"Expected index {expected} not found in {index_names}"
+
+    res = list(await db.fetch(f'SELECT * FROM "{table_name}" ORDER BY name'))
+    assert len(res) == 2
+    assert res[0]["name"] == "Alice"
+    assert res[1]["name"] == "Bob"
+
+
 async def test_csv_to_db_transaction_rollback_on_create_failure(db, clean_db, fake_check, mocker):
+    """When CREATE TABLE fails on the shadow table, the real table is untouched."""
     check = await fake_check()
     table_name = hashlib.md5(check["url"].encode("utf-8")).hexdigest()
 
@@ -131,7 +170,7 @@ async def test_csv_to_db_transaction_rollback_on_create_failure(db, clean_db, fa
     await db.execute(f'CREATE TABLE "{table_name}" (__id SERIAL PRIMARY KEY, val text)')
     await db.execute(f"INSERT INTO \"{table_name}\" (val) VALUES ('original-data')")
 
-    # Make CREATE fail so the transaction rolls back the DROP
+    # Make CREATE fail so the real table is never touched
     mocker.patch(
         "udata_hydra.data_formats.csv_like.to_db.compute_create_table_query",
         return_value="NOT A VALID SQL STATEMENT",
@@ -147,7 +186,7 @@ async def test_csv_to_db_transaction_rollback_on_create_failure(db, clean_db, fa
 
         assert exc.value.step == "create_table_query"
 
-    # Old table and data must survive the rollback
+    # Old table and data must survive
     res = await db.fetch(f'SELECT * FROM "{table_name}"')
     assert len(res) == 1
     assert res[0]["val"] == "original-data"
@@ -156,7 +195,7 @@ async def test_csv_to_db_transaction_rollback_on_create_failure(db, clean_db, fa
 
 
 async def test_csv_to_db_transaction_rollback_on_copy_failure(db, clean_db, fake_check, mocker):
-    """When copy_records_to_table fails, the whole transaction rolls back."""
+    """When copy_records_to_table fails, the shadow table is dropped and the real table is untouched."""
     check = await fake_check()
     table_name = hashlib.md5(check["url"].encode("utf-8")).hexdigest()
 
@@ -187,7 +226,7 @@ async def test_csv_to_db_transaction_rollback_on_copy_failure(db, clean_db, fake
 
         assert exc.value.step == "copy_records_to_table"
 
-    # Old table and data must survive the rollback
+    # Old table and data must survive
     res = await db.fetch(f'SELECT * FROM "{table_name}"')
     assert len(res) == 1
     assert res[0]["val"] == "original-data"

--- a/tests/test_conversion/test_csv_to_db.py
+++ b/tests/test_conversion/test_csv_to_db.py
@@ -119,3 +119,68 @@ async def test_reserved_column_name(db, clean_db, fake_check):
         table = await file.to_db(check=check)
     res = await db.fetchrow(f'SELECT * FROM "{table.table_name}"')
     assert res["xmin__hydra_renamed"] == "test"
+async def test_csv_to_db_transaction_rollback_on_create_failure(db, clean_db, fake_check, mocker):
+    check = await fake_check()
+    table_name = hashlib.md5(check["url"].encode("utf-8")).hexdigest()
+
+    # Simulate a previous successful import
+    await db.execute(f'CREATE TABLE "{table_name}" (__id SERIAL PRIMARY KEY, val text)')
+    await db.execute(f'INSERT INTO "{table_name}" (val) VALUES (\'original-data\')')
+
+    # Make CREATE fail so the transaction rolls back the DROP
+    mocker.patch(
+        "udata_hydra.data_formats.csv_like.to_db.compute_create_table_query",
+        return_value="NOT A VALID SQL STATEMENT",
+    )
+
+    with NamedTemporaryFile(dir=storage_path("")) as fp:
+        fp.write(b"val\nnew-data")
+        fp.seek(0)
+        file = Csv(file_name=os.path.basename(fp.name), resource_id=RESOURCE_ID)
+        await file.inspect()
+        with pytest.raises(ParseException):
+            await file.to_db(check=check)
+
+    # Old table and data must survive the rollback
+    res = await db.fetch(f'SELECT * FROM "{table_name}"')
+    assert len(res) == 1
+    assert res[0]["val"] == "original-data"
+
+    await db.execute(f'DROP TABLE IF EXISTS "{table_name}"')
+
+
+async def test_csv_to_db_transaction_rollback_on_copy_failure(db, clean_db, fake_check, mocker):
+    """When copy_records_to_table fails, the whole transaction rolls back."""
+    check = await fake_check()
+    table_name = hashlib.md5(check["url"].encode("utf-8")).hexdigest()
+
+    # Simulate a previous successful import
+    await db.execute(f'CREATE TABLE "{table_name}" (__id SERIAL PRIMARY KEY, val text)')
+    await db.execute(f'INSERT INTO "{table_name}" (val) VALUES (\'original-data\')')
+
+    # Make iter_tabular_rows return a generator that raises on iteration
+    def make_failing_iter(*args, **kwargs):
+        def _gen():
+            raise RuntimeError("simulated copy failure")
+            yield  # never reached
+        return _gen()
+
+    mocker.patch(
+        "udata_hydra.data_formats.csv_like.to_db.iter_tabular_rows",
+        make_failing_iter,
+    )
+
+    with NamedTemporaryFile(dir=storage_path("")) as fp:
+        fp.write(b"val\nnew-data")
+        fp.seek(0)
+        file = Csv(file_name=os.path.basename(fp.name), resource_id=RESOURCE_ID)
+        await file.inspect()
+        with pytest.raises(ParseException):
+            await file.to_db(check=check)
+
+    # Old table and data must survive the rollback
+    res = await db.fetch(f'SELECT * FROM "{table_name}"')
+    assert len(res) == 1
+    assert res[0]["val"] == "original-data"
+
+    await db.execute(f'DROP TABLE IF EXISTS "{table_name}"')

--- a/tests/test_conversion/test_csv_to_db.py
+++ b/tests/test_conversion/test_csv_to_db.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import os
 from datetime import date, datetime, timedelta, timezone
@@ -7,6 +8,7 @@ import pytest
 
 from tests.conftest import RESOURCE_ID
 from udata_hydra.data_formats import Csv
+from udata_hydra.utils import ParseException, storage_path
 
 pytestmark = pytest.mark.asyncio
 
@@ -27,7 +29,7 @@ async def test_csv_to_db_simple_type_casting(db, line_expected, clean_db, fake_c
     check = await fake_check()
     line, expected, separator = line_expected
     header = separator.join(["int", "float", "string", "bool"])
-    with NamedTemporaryFile() as fp:
+    with NamedTemporaryFile(dir=storage_path("")) as fp:
         fp.write(f"{header}\n{line}".encode("utf-8"))
         fp.seek(0)
         file = Csv(file_name=os.path.basename(fp.name), resource_id=RESOURCE_ID)
@@ -69,7 +71,7 @@ async def test_csv_to_db_simple_type_casting(db, line_expected, clean_db, fake_c
 async def test_csv_to_db_complex_type_casting(db, line_expected, clean_db, fake_check):
     check = await fake_check()
     line, expected = line_expected
-    with NamedTemporaryFile() as fp:
+    with NamedTemporaryFile(dir=storage_path("")) as fp:
         fp.write(f"json;date;datetime;aware_datetime\n{line}".encode("utf-8"))
         fp.seek(0)
         file = Csv(file_name=os.path.basename(fp.name), resource_id=RESOURCE_ID)
@@ -86,7 +88,7 @@ async def test_basic_sql_injection(db, clean_db, fake_check):
     # tries to execute
     # CREATE TABLE table_name("int" integer, "col_name" text);DROP TABLE toto;--)
     injection = 'col_name" text);DROP TABLE toto;--'
-    with NamedTemporaryFile() as fp:
+    with NamedTemporaryFile(dir=storage_path("")) as fp:
         # we enough columns so that the ";" is not considered as separator by csv-detective
         fp.write(f"int,{injection},col1,col2\n1,test,2,3".encode("utf-8"))
         fp.seek(0)
@@ -99,7 +101,7 @@ async def test_basic_sql_injection(db, clean_db, fake_check):
 
 async def test_percentage_column(db, clean_db, fake_check):
     check = await fake_check()
-    with NamedTemporaryFile() as fp:
+    with NamedTemporaryFile(dir=storage_path("")) as fp:
         fp.write("int,% mon pourcent\n1,test".encode("utf-8"))
         fp.seek(0)
         file = Csv(file_name=os.path.basename(fp.name), resource_id=RESOURCE_ID)
@@ -111,7 +113,7 @@ async def test_percentage_column(db, clean_db, fake_check):
 
 async def test_reserved_column_name(db, clean_db, fake_check):
     check = await fake_check()
-    with NamedTemporaryFile() as fp:
+    with NamedTemporaryFile(dir=storage_path("")) as fp:
         fp.write("int,xmin\n1,test".encode("utf-8"))
         fp.seek(0)
         file = Csv(file_name=os.path.basename(fp.name), resource_id=RESOURCE_ID)
@@ -119,6 +121,8 @@ async def test_reserved_column_name(db, clean_db, fake_check):
         table = await file.to_db(check=check)
     res = await db.fetchrow(f'SELECT * FROM "{table.table_name}"')
     assert res["xmin__hydra_renamed"] == "test"
+
+
 async def test_csv_to_db_transaction_rollback_on_create_failure(db, clean_db, fake_check, mocker):
     check = await fake_check()
     table_name = hashlib.md5(check["url"].encode("utf-8")).hexdigest()

--- a/tests/test_conversion/test_csv_to_geojson.py
+++ b/tests/test_conversion/test_csv_to_geojson.py
@@ -8,6 +8,7 @@ import pytest
 
 from udata_hydra.data_formats import Csv
 from udata_hydra.data_formats.csv_like.to_geojson import DEFAULT_GEOJSON_FILENAME
+from udata_hydra.utils import storage_path
 
 
 def _build_csv_content(columns: dict, sep: str = ";") -> str:
@@ -31,7 +32,7 @@ async def _geojson_from_csv_columns(
     except FileNotFoundError:
         pass
 
-    with NamedTemporaryFile(delete=False, suffix=".csv") as fp:
+    with NamedTemporaryFile(dir=storage_path(""), delete=False, suffix=".csv") as fp:
         fp.write(_build_csv_content(columns, sep).encode("utf-8"))
         fp.seek(0)
         csv_file = Csv(file_name=os.path.basename(fp.name))
@@ -176,7 +177,7 @@ async def test_csv_to_geojson_returns_none_without_geo_columns():
     except FileNotFoundError:
         pass
 
-    with NamedTemporaryFile(delete=False, suffix=".csv") as fp:
+    with NamedTemporaryFile(dir=storage_path(""), delete=False, suffix=".csv") as fp:
         fp.write(b"nombre;score\n1;0.5\n2;1.0\n")
         fp.seek(0)
         csv_file = Csv(file_name=os.path.basename(fp.name))

--- a/tests/test_conversion/test_db_to_geojson.py
+++ b/tests/test_conversion/test_db_to_geojson.py
@@ -37,7 +37,7 @@ async def _geojson_from_columns(
         pass
 
     check = await fake_check()
-    with NamedTemporaryFile(delete=False) as fp:
+    with NamedTemporaryFile(dir=storage_path(""), delete=False) as fp:
         fp.write(_build_csv_content(columns, sep).encode("utf-8"))
         fp.seek(0)
         file = Csv(file_name=os.path.basename(fp.name), resource_id=RESOURCE_ID)

--- a/udata_hydra/cli/purge.py
+++ b/udata_hydra/cli/purge.py
@@ -167,3 +167,49 @@ def purge_selected_csv_tables(
     return _make_async_wrapper(_purge_selected_csv_tables)(
         retention_days=retention_days, retention_tables=retention_tables, quiet=quiet
     )
+
+
+async def _purge_shadow_tables(
+    quiet: bool = False,
+) -> None:
+    """Drop all leftover shadow tables"""
+    with quiet_logs(enabled=quiet):
+        conn = await connection(db_name="csv")
+        res: list[Record] = await conn.fetch(
+            f"""SELECT tablename FROM pg_catalog.pg_tables
+            WHERE schemaname = '{config.DATABASE_SCHEMA}'
+            AND tablename ~ '^[0-9a-f]{{32}}_s[0-9a-f]{{4}}$'"""
+        )
+
+        if not res:
+            log.info("No shadow tables to purge.")
+            return
+
+        success_count = 0
+        error_count = 0
+        for row in res:
+            try:
+                await conn.execute(f'DROP TABLE IF EXISTS "{row["tablename"]}"')
+                success_count += 1
+            except Exception as e:
+                error_count += 1
+                log.error(f'Failed to drop shadow table "{row["tablename"]}": {e}')
+                continue
+
+        if success_count:
+            log.info(f"Dropped {success_count} shadow table(s).")
+        if error_count:
+            log.warning(f"Failed to drop {error_count} shadow table(s).")
+
+
+@cli.command()
+def purge_shadow_tables(
+    quiet: bool = typer.Option(False, help="Ignore logs except for errors"),
+) -> Coroutine[Any, Any, None]:
+    """Drop leftover shadow tables. You should stop workers first to prevent deleting an in-use shadow table."""
+    typer.echo(
+        "WARNING: Make sure no workers are currently importing data, "
+        "otherwise an in-use shadow table could be dropped."
+    )
+    typer.confirm("Continue?", abort=True)
+    return _make_async_wrapper(_purge_shadow_tables)(quiet=quiet)

--- a/udata_hydra/data_formats/csv_like/to_db.py
+++ b/udata_hydra/data_formats/csv_like/to_db.py
@@ -64,46 +64,35 @@ async def csv_to_db(
     # build a `column_name: type` mapping and explicitely rename reserved column names
     columns = {db_col_name(c): helpers.get_python_type(v) for c, v in inspection["columns"].items()}
 
-    q = f'DROP TABLE IF EXISTS "{table_name}"'
     db = await context.pool("csv")
-    await db.execute(q)
-
-    # Create table
-    q = compute_create_table_query(table_name=table_name, columns=columns, indexes=table_indexes)
+    step = "create_table_query"
     try:
-        await db.execute(q)
+        async with db.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(f'DROP TABLE IF EXISTS "{table_name}"')
+                q_create = compute_create_table_query(table_name=table_name, columns=columns, indexes=table_indexes)
+                await conn.execute(q_create)
+
+                step = "copy_records_to_table"
+                if not debug_insert:
+                    await conn.copy_records_to_table(
+                        table_name,
+                        records=iter_tabular_rows(file.path, inspection, cast_json=False),
+                        columns=list(columns.keys()),
+                    )
+                else:
+                    bar = ProgressBar(total=inspection["total_lines"])
+                    for r in bar.iter(iter_tabular_rows(file.path, inspection, cast_json=False)):
+                        data = {k: v for k, v in zip(inspection["columns"], r)}
+                        q = compute_insert_query(table_name=table_name, data=data, returning="__id")
+                        await conn.execute(q, *data.values())
     except Exception as e:
         raise ParseException(
             message=str(e),
-            step="create_table_query",
+            step=step,
             resource_id=file.resource_id,
             table_name=table_name,
         ) from e
-
-    # this use postgresql COPY from an iterator, it's fast but might be difficult to debug
-    if not debug_insert:
-        # NB: also see copy_to_table for a file source
-        try:
-            await db.copy_records_to_table(
-                table_name,
-                records=iter_tabular_rows(file.path, inspection, cast_json=False),
-                columns=list(columns.keys()),
-            )
-        except Exception as e:  # I know what I'm doing, pinky swear
-            raise ParseException(
-                message=str(e),
-                step="copy_records_to_table",
-                resource_id=file.resource_id,
-                table_name=table_name,
-            ) from e
-    # this inserts rows from iterator one by one, slow but useful for debugging
-    else:
-        bar = ProgressBar(total=inspection["total_lines"])
-        for r in bar.iter(iter_tabular_rows(file.path, inspection, cast_json=False)):
-            data = {k: v for k, v in zip(inspection["columns"], r)}
-            # NB: possible sql injection here, but should not be used in prod
-            q = compute_insert_query(table_name=table_name, data=data, returning="__id")
-            await db.execute(q, *data.values())
 
     check = await Check.update(check["id"], {"parsing_table": table_name})  # type: ignore[assignment]
     await insert_tables_index_entry(table_name, file.inspection, check, file.dataset_id)

--- a/udata_hydra/data_formats/csv_like/to_db.py
+++ b/udata_hydra/data_formats/csv_like/to_db.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import uuid
 from typing import TYPE_CHECKING
 
 from csv_detective.detection.engine import engine_to_file
@@ -64,32 +65,58 @@ async def csv_to_db(
     # build a `column_name: type` mapping and explicitely rename reserved column names
     columns = {db_col_name(c): helpers.get_python_type(v) for c, v in inspection["columns"].items()}
 
+    shadow_table_name = f"{table_name}_s{uuid.uuid4().hex[:4]}"
     db = await context.pool("csv")
-    step = "drop_table"
+
+    step = None
     try:
+        step = "create_table_query"
         async with db.acquire() as conn:
             async with conn.transaction():
-                await conn.execute(f'DROP TABLE IF EXISTS "{table_name}"')
-                step = "create_table_query"
                 q_create = compute_create_table_query(
-                    table_name=table_name, columns=columns, indexes=table_indexes
+                    table_name=shadow_table_name, columns=columns, indexes=table_indexes
                 )
                 await conn.execute(q_create)
 
-                step = "copy_records_to_table"
-                if not debug_insert:
-                    await conn.copy_records_to_table(
-                        table_name,
-                        records=iter_tabular_rows(file.path, inspection, cast_json=False),
-                        columns=list(columns.keys()),
+        step = "copy_records_to_table"
+        async with db.acquire() as conn:
+            if not debug_insert:
+                await conn.copy_records_to_table(
+                    shadow_table_name,
+                    records=iter_tabular_rows(file.path, inspection, cast_json=False),
+                    columns=list(columns.keys()),
+                )
+            else:
+                bar = ProgressBar(total=inspection["total_lines"])
+                for r in bar.iter(iter_tabular_rows(file.path, inspection, cast_json=False)):
+                    data = {k: v for k, v in zip(inspection["columns"], r)}
+                    q = compute_insert_query(
+                        table_name=shadow_table_name, data=data, returning="__id"
                     )
-                else:
-                    bar = ProgressBar(total=inspection["total_lines"])
-                    for r in bar.iter(iter_tabular_rows(file.path, inspection, cast_json=False)):
-                        data = {k: v for k, v in zip(inspection["columns"], r)}
-                        q = compute_insert_query(table_name=table_name, data=data, returning="__id")
-                        await conn.execute(q, *data.values())
+                    await conn.execute(q, *data.values())
+
+        step = "swap_tables"
+        async with db.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(f'DROP TABLE IF EXISTS "{table_name}"')
+                await conn.execute(f'ALTER TABLE "{shadow_table_name}" RENAME TO "{table_name}"')
+                rows = await conn.fetch(
+                    "SELECT indexname FROM pg_indexes WHERE tablename = $1 AND schemaname = $2",
+                    table_name,
+                    config.DATABASE_SCHEMA,
+                )
+                for row in rows:
+                    if row["indexname"].startswith(shadow_table_name):
+                        new_name = f"{table_name}{row['indexname'][len(shadow_table_name) :]}"
+                        if new_name != row["indexname"]:
+                            q = f'"{config.DATABASE_SCHEMA}"."{row["indexname"]}"'
+                            await conn.execute(f'ALTER INDEX IF EXISTS {q} RENAME TO "{new_name}"')
     except Exception as e:
+        try:
+            async with db.acquire() as conn:
+                await conn.execute(f'DROP TABLE IF EXISTS "{shadow_table_name}"')
+        except Exception:
+            log.warning("Failed to clean up shadow table %s", shadow_table_name)
         raise ParseException(
             message=str(e),
             step=step,

--- a/udata_hydra/data_formats/csv_like/to_db.py
+++ b/udata_hydra/data_formats/csv_like/to_db.py
@@ -70,7 +70,9 @@ async def csv_to_db(
         async with db.acquire() as conn:
             async with conn.transaction():
                 await conn.execute(f'DROP TABLE IF EXISTS "{table_name}"')
-                q_create = compute_create_table_query(table_name=table_name, columns=columns, indexes=table_indexes)
+                q_create = compute_create_table_query(
+                    table_name=table_name, columns=columns, indexes=table_indexes
+                )
                 await conn.execute(q_create)
 
                 step = "copy_records_to_table"

--- a/udata_hydra/data_formats/csv_like/to_db.py
+++ b/udata_hydra/data_formats/csv_like/to_db.py
@@ -65,11 +65,12 @@ async def csv_to_db(
     columns = {db_col_name(c): helpers.get_python_type(v) for c, v in inspection["columns"].items()}
 
     db = await context.pool("csv")
-    step = "create_table_query"
+    step = "drop_table"
     try:
         async with db.acquire() as conn:
             async with conn.transaction():
                 await conn.execute(f'DROP TABLE IF EXISTS "{table_name}"')
+                step = "create_table_query"
                 q_create = compute_create_table_query(
                     table_name=table_name, columns=columns, indexes=table_indexes
                 )

--- a/udata_hydra/data_formats/parquet/to_db.py
+++ b/udata_hydra/data_formats/parquet/to_db.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import logging
+import uuid
 from typing import TYPE_CHECKING, Iterator
 
 import numpy as np
@@ -85,33 +86,59 @@ async def parquet_to_db(
         db_col_name(c): helpers.get_python_type(v) for c, v in file.inspection["columns"].items()
     }
 
+    shadow_table_name = f"{table_name}_s{uuid.uuid4().hex[:4]}"
     db = await context.pool("csv")
-    step = "create_table_query"
+
+    step = None
     try:
+        step = "create_table_query"
         async with db.acquire() as conn:
             async with conn.transaction():
-                await conn.execute(f'DROP TABLE IF EXISTS "{table_name}"')
                 q_create = compute_create_table_query(
-                    table_name=table_name, columns=columns, indexes=table_indexes
+                    table_name=shadow_table_name, columns=columns, indexes=table_indexes
                 )
                 await conn.execute(q_create)
 
-                step = "copy_records_to_table"
-                if not debug_insert:
-                    await conn.copy_records_to_table(
-                        table_name,
-                        records=_iter_parquet_rows(pq.ParquetFile(file.path)),
-                        columns=list(columns.keys()),
+        step = "copy_records_to_table"
+        async with db.acquire() as conn:
+            if not debug_insert:
+                await conn.copy_records_to_table(
+                    shadow_table_name,
+                    records=_iter_parquet_rows(pq.ParquetFile(file.path)),
+                    columns=list(columns.keys()),
+                )
+            else:
+                bar = ProgressBar(total=file.inspection["total_lines"])
+                pqf = pq.ParquetFile(file.path)
+                for r in bar.iter(_iter_parquet_rows(pqf)):
+                    data = {k: v for k, v in zip(pqf.schema.names, r)}
+                    q = compute_insert_query(
+                        table_name=shadow_table_name, data=data, returning="__id"
                     )
-                else:
-                    bar = ProgressBar(total=file.inspection["total_lines"])
-                    pqf = pq.ParquetFile(file.path)
-                    for r in bar.iter(_iter_parquet_rows(pqf)):
-                        data = {k: v for k, v in zip(pqf.schema.names, r)}
-                        print(data)
-                        q = compute_insert_query(table_name=table_name, data=data, returning="__id")
-                        await conn.execute(q, *data.values())
+                    await conn.execute(q, *data.values())
+
+        step = "swap_tables"
+        async with db.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(f'DROP TABLE IF EXISTS "{table_name}"')
+                await conn.execute(f'ALTER TABLE "{shadow_table_name}" RENAME TO "{table_name}"')
+                rows = await conn.fetch(
+                    "SELECT indexname FROM pg_indexes WHERE tablename = $1 AND schemaname = $2",
+                    table_name,
+                    config.DATABASE_SCHEMA,
+                )
+                for row in rows:
+                    if row["indexname"].startswith(shadow_table_name):
+                        new_name = f"{table_name}{row['indexname'][len(shadow_table_name) :]}"
+                        if new_name != row["indexname"]:
+                            q = f'"{config.DATABASE_SCHEMA}"."{row["indexname"]}"'
+                            await conn.execute(f'ALTER INDEX IF EXISTS {q} RENAME TO "{new_name}"')
     except Exception as e:
+        try:
+            async with db.acquire() as conn:
+                await conn.execute(f'DROP TABLE IF EXISTS "{shadow_table_name}"')
+        except Exception:
+            log.warning("Failed to clean up shadow table %s", shadow_table_name)
         raise ParseException(
             message=str(e),
             step=step,

--- a/udata_hydra/data_formats/parquet/to_db.py
+++ b/udata_hydra/data_formats/parquet/to_db.py
@@ -85,48 +85,37 @@ async def parquet_to_db(
         db_col_name(c): helpers.get_python_type(v) for c, v in file.inspection["columns"].items()
     }
 
-    q = f'DROP TABLE IF EXISTS "{table_name}"'
     db = await context.pool("csv")
-    await db.execute(q)
-
-    # Create table
-    q = compute_create_table_query(table_name=table_name, columns=columns, indexes=table_indexes)
+    step = "create_table_query"
     try:
-        await db.execute(q)
+        async with db.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(f'DROP TABLE IF EXISTS "{table_name}"')
+                q_create = compute_create_table_query(table_name=table_name, columns=columns, indexes=table_indexes)
+                await conn.execute(q_create)
+
+                step = "copy_records_to_table"
+                if not debug_insert:
+                    await conn.copy_records_to_table(
+                        table_name,
+                        records=_iter_parquet_rows(pq.ParquetFile(file.path)),
+                        columns=list(columns.keys()),
+                    )
+                else:
+                    bar = ProgressBar(total=file.inspection["total_lines"])
+                    pqf = pq.ParquetFile(file.path)
+                    for r in bar.iter(_iter_parquet_rows(pqf)):
+                        data = {k: v for k, v in zip(pqf.schema.names, r)}
+                        print(data)
+                        q = compute_insert_query(table_name=table_name, data=data, returning="__id")
+                        await conn.execute(q, *data.values())
     except Exception as e:
         raise ParseException(
             message=str(e),
-            step="create_table_query",
+            step=step,
             resource_id=file.resource_id,
             table_name=table_name,
         ) from e
-
-    # this use postgresql COPY from an iterator, it's fast but might be difficult to debug
-    if not debug_insert:
-        # NB: also see copy_to_table for a file source
-        try:
-            await db.copy_records_to_table(
-                table_name,
-                records=_iter_parquet_rows(pq.ParquetFile(file.path)),
-                columns=list(columns.keys()),
-            )
-        except Exception as e:  # I know what I'm doing, pinky swear
-            raise ParseException(
-                message=str(e),
-                step="copy_records_to_table",
-                resource_id=file.resource_id,
-                table_name=table_name,
-            ) from e
-    # this inserts rows from iterator one by one, slow but useful for debugging
-    else:
-        bar = ProgressBar(total=file.inspection["total_lines"])
-        pqf = pq.ParquetFile(file.path)
-        for r in bar.iter(_iter_parquet_rows(pqf)):
-            data = {k: v for k, v in zip(pqf.schema.names, r)}
-            print(data)
-            # NB: possible sql injection here, but should not be used in prod
-            q = compute_insert_query(table_name=table_name, data=data, returning="__id")
-            await db.execute(q, *data.values())
 
     check = await Check.update(check["id"], {"parsing_table": table_name})  # type: ignore[assignment]
     await insert_tables_index_entry(table_name, file.inspection, check, file.dataset_id)

--- a/udata_hydra/data_formats/parquet/to_db.py
+++ b/udata_hydra/data_formats/parquet/to_db.py
@@ -91,7 +91,9 @@ async def parquet_to_db(
         async with db.acquire() as conn:
             async with conn.transaction():
                 await conn.execute(f'DROP TABLE IF EXISTS "{table_name}"')
-                q_create = compute_create_table_query(table_name=table_name, columns=columns, indexes=table_indexes)
+                q_create = compute_create_table_query(
+                    table_name=table_name, columns=columns, indexes=table_indexes
+                )
                 await conn.execute(q_create)
 
                 step = "copy_records_to_table"


### PR DESCRIPTION
The objectives are :
- to prevent a table deletion if the following creation or upserting fails
- to prevent users from getting partially fed table during `copy_records_to_table` (that can take up to some minutes)

~~We could have gone with a table swap by changing names, but since we have indexes, it would require updating the indexes name and sounded more cumbersome. Let me know if there are other considerations.~~
We went for a table swap to prevent READ lock during the table creation and insertion.