### PR TITLE
feat: store distinct code commune values

### DIFF
--- a/tests/test_analysis/test_analysis_csv.py
+++ b/tests/test_analysis/test_analysis_csv.py
@@ -759,9 +759,9 @@ async def test_file_with_nan(
     assert profile["c"]["min"] is not None
 
 
-CODE_COMMUNE_CSV_CONTENT = (
-    "code_commune,number\n75056,1\n13055,2\n69123,3\n75056,4\n"
-).encode("utf-8")
+CODE_COMMUNE_CSV_CONTENT = ("code_commune,number\n75056,1\n13055,2\n69123,3\n75056,4\n").encode(
+    "utf-8"
+)
 
 
 async def test_analyse_csv_extracts_code_commune_values(

--- a/tests/test_analysis/test_analysis_csv.py
+++ b/tests/test_analysis/test_analysis_csv.py
@@ -757,3 +757,51 @@ async def test_file_with_nan(
     # inf does for max, mean and std
     assert all(profile["c"][method] is None for method in ["max", "mean", "std"])
     assert profile["c"]["min"] is not None
+
+
+CODE_COMMUNE_CSV_CONTENT = (
+    "code_commune,number\n75056,1\n13055,2\n69123,3\n75056,4\n"
+).encode("utf-8")
+
+
+async def test_analyse_csv_extracts_code_commune_values(
+    setup_catalog, rmock, db, fake_check, udata_url
+):
+    check = await fake_check(headers={"content-type": "text/csv"})
+    url = check["url"]
+    table_name = hashlib.md5(url.encode("utf-8")).hexdigest()
+    rmock.get(url, status=200, body=CODE_COMMUNE_CSV_CONTENT)
+    rmock.put(udata_url, status=200)
+
+    file = await download_from_check(check, Csv)
+    await file.analyse(check=check)
+
+    res = await db.fetchrow("SELECT * FROM checks")
+    assert res["parsing_table"] == table_name
+    values = res["code_commune_values"]
+    if isinstance(values, str):
+        values = json.loads(values)
+    assert values == {"code_commune": ["13055", "69123", "75056"]}
+
+    webhook = rmock.requests[("PUT", URL(udata_url))][0].kwargs["json"]
+    assert webhook.get("analysis:parsing:code_commune_values") == {
+        "code_commune": ["13055", "69123", "75056"]
+    }
+
+
+async def test_analyse_csv_no_code_commune_column_skips_extraction(
+    setup_catalog, rmock, catalog_content, db, fake_check, udata_url
+):
+    check = await fake_check(headers={"content-type": "text/csv"})
+    url = check["url"]
+    rmock.get(url, status=200, body=catalog_content)
+    rmock.put(udata_url, status=200)
+
+    file = await download_from_check(check, Csv)
+    await file.analyse(check=check)
+
+    res = await db.fetchrow("SELECT * FROM checks")
+    assert res["code_commune_values"] is None
+
+    webhook = rmock.requests[("PUT", URL(udata_url))][0].kwargs["json"]
+    assert webhook.get("analysis:parsing:code_commune_values") is None

--- a/tests/test_analysis/test_analysis_helpers.py
+++ b/tests/test_analysis/test_analysis_helpers.py
@@ -105,6 +105,11 @@ async def test_notify_udata_raises_without_check_or_resource(missing):
             {"geojson_url": "https://example.com/file.geojson", "geojson_size": 77},
             ["analysis:parsing:geojson_url", "analysis:parsing:geojson_size"],
         ),
+        (
+            "CODE_COMMUNE_ANALYSIS_ENABLED",
+            {"code_commune_values": {"code_commune": ["13055", "75056"]}},
+            ["analysis:parsing:code_commune_values"],
+        ),
     ),
 )
 async def test_notify_udata_includes_optional_payload_fields(
@@ -149,3 +154,23 @@ async def test_notify_udata_parses_string_ogc_metadata(mocker):
 
     document = enqueue.call_args.kwargs["document"].payload
     assert document["analysis:parsing:ogc_metadata"] == ogc_metadata
+
+
+@pytest.mark.asyncio
+async def test_notify_udata_parses_string_code_commune_values(mocker):
+    enqueue = mocker.patch("udata_hydra.analysis.helpers.queue.enqueue")
+    mocker.patch("udata_hydra.config.CODE_COMMUNE_ANALYSIS_ENABLED", True)
+
+    code_commune_values = {"code_commune": ["13055", "75056"]}
+    check = {
+        "resource_id": "resource-id",
+        "parsing_started_at": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        "parsing_finished_at": datetime(2024, 1, 2, tzinfo=timezone.utc),
+        "code_commune_values": json.dumps(code_commune_values),
+    }
+    resource = {"dataset_id": "dataset-id"}
+
+    await helpers.notify_udata(resource, check)
+
+    document = enqueue.call_args.kwargs["document"].payload
+    assert document["analysis:parsing:code_commune_values"] == code_commune_values

--- a/udata_hydra/analysis/helpers.py
+++ b/udata_hydra/analysis/helpers.py
@@ -102,5 +102,10 @@ async def notify_udata(resource: Record | None, check: Record | dict | None) -> 
         if isinstance(ogc_metadata, str):
             ogc_metadata = json.loads(ogc_metadata)
         payload["document"]["analysis:parsing:ogc_metadata"] = ogc_metadata
+    if config.CODE_COMMUNE_ANALYSIS_ENABLED and check.get("code_commune_values"):
+        code_commune_values = check.get("code_commune_values")
+        if isinstance(code_commune_values, str):
+            code_commune_values = json.loads(code_commune_values)
+        payload["document"]["analysis:parsing:code_commune_values"] = code_commune_values
     payload["document"] = UdataPayload(payload["document"])
     queue.enqueue(send, _priority="high", **payload)

--- a/udata_hydra/config_default.toml
+++ b/udata_hydra/config_default.toml
@@ -75,6 +75,10 @@ CSV_ANALYSIS = true
 CSV_TO_DB = true
 TEMPORARY_DOWNLOAD_FOLDER = ""
 
+# -- Code commune (INSEE) distinct values extraction settings -- #
+CODE_COMMUNE_ANALYSIS_ENABLED = true
+MAX_CODE_COMMUNE_VALUES = 40000  # there are ~35 000 communes in France; cap slightly above that
+
 # -- Worker settings -- #
 RQ_DEFAULT_TIMEOUT = 180
 RQ_DEFAULT_FAILURE_TTL = 864000  # How long failed jobs are kept in redis: 10 days.

--- a/udata_hydra/config_default.toml
+++ b/udata_hydra/config_default.toml
@@ -77,7 +77,7 @@ TEMPORARY_DOWNLOAD_FOLDER = ""
 
 # -- Code commune (INSEE) distinct values extraction settings -- #
 CODE_COMMUNE_ANALYSIS_ENABLED = true
-MAX_CODE_COMMUNE_VALUES = 40000  # there are ~35 000 communes in France; cap slightly above that
+MAX_CODE_COMMUNE_VALUES = 40000
 
 # -- Worker settings -- #
 RQ_DEFAULT_TIMEOUT = 180

--- a/udata_hydra/data_formats/csv_like/__init__.py
+++ b/udata_hydra/data_formats/csv_like/__init__.py
@@ -116,6 +116,25 @@ class CsvLike(DataFormat):
                 },
             )
 
+            if config.CSV_TO_DB and table is not None:
+                try:
+                    from udata_hydra.data_formats.csv_like.code_commune import (
+                        extract_code_commune_values,
+                    )
+
+                    code_commune_values = await extract_code_commune_values(table)
+                    if code_commune_values:
+                        check = await Check.update(  # type: ignore[assignment]
+                            check_id=check["id"],
+                            data={"code_commune_values": code_commune_values},
+                        )
+                except Exception as e:
+                    # Supplementary metadata only — never fail the whole analysis for this.
+                    log.warning(
+                        f"Failed to extract code_commune distinct values for "
+                        f"{table.table_name if table else '?'}: {e}"
+                    )
+
             if config.CSV_TO_DB:
                 if (
                     config.DB_TO_PARQUET

--- a/udata_hydra/data_formats/csv_like/__init__.py
+++ b/udata_hydra/data_formats/csv_like/__init__.py
@@ -116,7 +116,7 @@ class CsvLike(DataFormat):
                 },
             )
 
-            if config.CSV_TO_DB and table is not None:
+            if config.CSV_TO_DB and config.CODE_COMMUNE_ANALYSIS_ENABLED and table is not None:
                 try:
                     code_commune_values = await table.get_code_commune_values()
                     if code_commune_values:

--- a/udata_hydra/data_formats/csv_like/__init__.py
+++ b/udata_hydra/data_formats/csv_like/__init__.py
@@ -118,11 +118,7 @@ class CsvLike(DataFormat):
 
             if config.CSV_TO_DB and table is not None:
                 try:
-                    from udata_hydra.data_formats.csv_like.code_commune import (
-                        extract_code_commune_values,
-                    )
-
-                    code_commune_values = await extract_code_commune_values(table)
+                    code_commune_values = await table.get_code_commune_values()
                     if code_commune_values:
                         check = await Check.update(  # type: ignore[assignment]
                             check_id=check["id"],

--- a/udata_hydra/data_formats/csv_like/code_commune.py
+++ b/udata_hydra/data_formats/csv_like/code_commune.py
@@ -1,0 +1,53 @@
+import logging
+
+from udata_hydra import config, context
+from udata_hydra.data_formats.table import Table
+from udata_hydra.db import db_col_name
+
+log = logging.getLogger("udata-hydra")
+
+
+def _detect_code_commune_columns(inspection: dict) -> dict[str, str]:
+    """Map original column name -> postgres column name, for every column
+    csv_detective tagged as format == "code_commune"."""
+    return {
+        column: db_col_name(column)
+        for column, detection in inspection["columns"].items()
+        if detection.get("format") == "code_commune"
+    }
+
+
+async def extract_code_commune_values(table: Table) -> dict[str, list[str]] | None:
+    """Query the just-populated parsing table for distinct values of every
+    code_commune column. Returns None if there are no such columns, or if
+    none of them yielded a usable (within-cap) result."""
+    if not config.CODE_COMMUNE_ANALYSIS_ENABLED:
+        return None
+
+    columns = _detect_code_commune_columns(table.inspection)
+    if not columns:
+        return None
+
+    db = await context.pool("csv")
+    result: dict[str, list[str]] = {}
+    cap = config.MAX_CODE_COMMUNE_VALUES
+
+    for original_col, db_col in columns.items():
+        q = f'''
+            SELECT DISTINCT "{db_col}" AS value
+            FROM "{table.table_name}"
+            WHERE "{db_col}" IS NOT NULL
+            LIMIT {cap + 1}
+        '''
+        rows = await db.fetch(q)
+        values = [r["value"] for r in rows]
+        if len(values) > cap:
+            log.warning(
+                f"code_commune column '{original_col}' on table {table.table_name} has more "
+                f"than {cap} distinct values, skipping (likely a bad detection)"
+            )
+            continue
+        if values:
+            result[original_col] = sorted(str(v) for v in values)
+
+    return result or None

--- a/udata_hydra/data_formats/table/__init__.py
+++ b/udata_hydra/data_formats/table/__init__.py
@@ -36,3 +36,9 @@ class Table(DataFormat):
 
         if config.DB_TO_GEOJSON:
             return await db_to_geojson(table=self)
+
+    async def get_code_commune_values(self) -> dict[str, list[str]] | None:
+        from udata_hydra.data_formats.table.code_commune import extract_code_commune_values
+
+        if config.CODE_COMMUNE_ANALYSIS_ENABLED:
+            return await extract_code_commune_values(table=self)

--- a/udata_hydra/data_formats/table/code_commune.py
+++ b/udata_hydra/data_formats/table/code_commune.py
@@ -25,6 +25,8 @@ async def extract_code_commune_values(table: Table) -> dict[str, list[str]] | No
     if not columns:
         return None
 
+    log.debug(f"Detected code_commune column(s) {list(columns)} for table {table.table_name}")
+
     db = await context.pool("csv")
     result: dict[str, list[str]] = {}
     cap = config.MAX_CODE_COMMUNE_VALUES
@@ -46,5 +48,9 @@ async def extract_code_commune_values(table: Table) -> dict[str, list[str]] | No
             continue
         if values:
             result[original_col] = sorted(str(v) for v in values)
+            log.debug(
+                f"Extracted {len(values)} distinct code_commune value(s) for column "
+                f"'{original_col}' on table {table.table_name}"
+            )
 
     return result or None

--- a/udata_hydra/data_formats/table/code_commune.py
+++ b/udata_hydra/data_formats/table/code_commune.py
@@ -1,7 +1,7 @@
 import logging
 
 from udata_hydra import config, context
-from udata_hydra.data_formats.table import Table
+from udata_hydra.data_formats import Table
 from udata_hydra.db import db_col_name
 
 log = logging.getLogger("udata-hydra")
@@ -18,12 +18,9 @@ def _detect_code_commune_columns(inspection: dict) -> dict[str, str]:
 
 
 async def extract_code_commune_values(table: Table) -> dict[str, list[str]] | None:
-    """Query the just-populated parsing table for distinct values of every
-    code_commune column. Returns None if there are no such columns, or if
-    none of them yielded a usable (within-cap) result."""
-    if not config.CODE_COMMUNE_ANALYSIS_ENABLED:
-        return None
-
+    """Query the parsing table for distinct values of every code_commune column.
+    Returns None if there are no such columns, or if none of them yielded a
+    usable (within-cap) result."""
     columns = _detect_code_commune_columns(table.inspection)
     if not columns:
         return None

--- a/udata_hydra/migrations/main/20260701_add_code_commune_values.sql
+++ b/udata_hydra/migrations/main/20260701_add_code_commune_values.sql
@@ -1,0 +1,4 @@
+-- Add code_commune distinct values column to checks table
+
+ALTER TABLE checks
+    ADD COLUMN code_commune_values JSONB;

--- a/udata_hydra/utils/http.py
+++ b/udata_hydra/utils/http.py
@@ -47,6 +47,7 @@ class UdataPayload:
             "geojson_size",
             "geojson_url",
             "ogc_metadata",
+            "code_commune_values",
         ],
     }
 


### PR DESCRIPTION
Extracts distinct `code_commune` values from a CSV table when `csv_detective` says there is at least one.

Data is stored as JSONB in `check.code_commune_values` and then sent to `udata` as `analysis:parsing:code_commune_values`.

It's a dict with shape:

```
{
  "{col_A}": ["{code_insee_1}", ...],
  "{col_B}": ["{code_insee_2}", ...]
}
```

TODO:
- [ ] evaluate needed size re existing catalog @streino 
- [ ] generalise to other codes: department, region... just duplicate columns or use the INSEE-prefixed codes in a global list?
- [ ] validate shape: do we want all columns or select one? (most populated, most confidently detected...)
- [ ] validate `udata` storage: do we want an `extras.detected_spatial.zones[]` with the same shape and literal values as `spatial.zones[]` (eg `fr:commune:1234` instead of `1234`), with a validation of the code? Whose responsibility is this?