### PR TITLE
fix: check head request fallback

### DIFF
--- a/tests/test_crawl/test_crawl.py
+++ b/tests/test_crawl/test_crawl.py
@@ -235,18 +235,29 @@ async def test_deleted_check(setup_catalog, rmock, fake_check, produce_mock):
     [
         pytest.param(501, None, id="invalid_status"),
         pytest.param(200, {}, id="missing_size_headers"),
+        pytest.param(
+            200,
+            {"content-type": "text/html", "content-length": "247"},
+            id="waf_html_headers",
+        ),
     ],
 )
-async def test_switch_head_to_get(setup_catalog, rmock, produce_mock, head_status, head_headers):
+async def test_switch_head_to_get(
+    setup_catalog, rmock, produce_mock, analysis_mock, db, head_status, head_headers
+):
     rurl = RESOURCE_URL
     head_kwargs = {"status": head_status}
     if head_headers is not None:
         head_kwargs["headers"] = head_headers
     rmock.head(rurl, **head_kwargs)
-    rmock.get(rurl, status=200)
+    rmock.get(rurl, status=200, headers={"content-length": "10"})
     await start_checks(iterations=1)
     assert ("HEAD", URL(rurl)) in rmock.requests
     assert ("GET", URL(rurl)) in rmock.requests
+
+    res = await db.fetchrow("SELECT * FROM checks WHERE url = $1", rurl)
+    assert res["status"] == 200
+    assert not res["error"]
 
 
 async def test_no_switch_head_to_get(setup_catalog, rmock, produce_mock, analysis_mock):

--- a/udata_hydra/crawl/helpers.py
+++ b/udata_hydra/crawl/helpers.py
@@ -50,6 +50,13 @@ def has_nice_head(resp) -> bool:
         return False
     if not any([k in resp.headers for k in ("content-length", "last-modified")]):
         return False
+    content_type = resp.headers.get("content-type", "").lower()
+    if content_type.startswith("text/html"):
+        try:
+            if int(resp.headers.get("content-length", 0)) < 4096:
+                return False
+        except (TypeError, ValueError):
+            return False
     return True
 
 

--- a/udata_hydra/crawl/helpers.py
+++ b/udata_hydra/crawl/helpers.py
@@ -5,6 +5,10 @@ from multidict import CIMultiDictProxy
 
 from udata_hydra import config, context
 
+# WAF block pages often return HTTP 200 on HEAD with text/html and a tiny body
+# (e.g. "Request Rejected", ~247 bytes). Treat those as unreliable HEAD responses.
+SUSPICIOUS_HTML_HEAD_MAX_BYTES = 4096
+
 
 async def get_content_type_from_header(headers: dict) -> str:
     """
@@ -53,7 +57,7 @@ def has_nice_head(resp) -> bool:
     content_type = resp.headers.get("content-type", "").lower()
     if content_type.startswith("text/html"):
         try:
-            if int(resp.headers.get("content-length", 0)) < 4096:
+            if int(resp.headers.get("content-length", 0)) < SUSPICIOUS_HTML_HEAD_MAX_BYTES:
                 return False
         except (TypeError, ValueError):
             return False


### PR DESCRIPTION
When crawling resource `ac59a0f5-fa83-4b82-bf12-3c5806d4f19f` (`monactiviteformation.emploi.gouv.fr`), Hydra’s HEAD request can succeed with HTTP 200 while the response is actually a short WAF page (text/html, e.g. “Request Rejected”, in our case text/html, content-length: 247) instead of the CSV file. `has_nice_head()` treated that as a valid HEAD response, so Hydra skipped the existing GET fallback and recorded a misleading successful check.

This change tightens `has_nice_head()`: a HEAD response with text/html and a small Content-Length (< 4 KB) is now considered unreliable, triggering the existing `HEAD`->`GET` fallback in check_resource. A regression test covers the case.