### PR TITLE
fix(crawl): fallback to GET when HEAD times out

### DIFF
--- a/tests/test_crawl/test_crawl.py
+++ b/tests/test_crawl/test_crawl.py
@@ -44,7 +44,7 @@ async def mock_download_resource(url, headers, max_size_allowed):
         (None, False, ClientError("client error")),
         (None, False, AssertionError),
         (None, False, UnicodeError),
-        (None, True, TimeoutError),
+        (200, False, TimeoutError),
         (
             429,
             False,
@@ -60,14 +60,18 @@ async def mock_download_resource(url, headers, max_size_allowed):
 async def test_crawl(setup_catalog, rmock, db, resource, analysis_mock, udata_url):
     status, timeout, exception = resource
     rurl = RESOURCE_URL
-    params = {
-        "status": status,
-        "headers": {"Content-LENGTH": "10", "X-Do": "you"},
-        "exception": exception,
-    }
-    rmock.head(rurl, **params)
-    # mock for head fallback
-    rmock.get(rurl, **params)
+    ok_headers = {"Content-LENGTH": "10", "X-Do": "you"}
+    if exception is TimeoutError:
+        rmock.head(rurl, exception=TimeoutError)
+        rmock.get(rurl, status=200, headers=ok_headers)
+    else:
+        params = {
+            "status": status,
+            "headers": ok_headers,
+            "exception": exception,
+        }
+        rmock.head(rurl, **params)
+        rmock.get(rurl, **params)
     rmock.options(
         rurl,
         status=204,
@@ -95,6 +99,8 @@ async def test_crawl(setup_catalog, rmock, db, resource, analysis_mock, udata_ur
     assert res["timeout"] == timeout
     if isinstance(exception, ClientError):
         assert res["error"] == "client error"
+    elif exception is TimeoutError:
+        assert not res["error"]
     elif status == 500:
         assert res["error"] == "Internal Server Error"
     else:
@@ -105,7 +111,11 @@ async def test_crawl(setup_catalog, rmock, db, resource, analysis_mock, udata_ur
     webhook = next(p for p in payloads if "check:id" in p)
     assert webhook.get("check:date")
     datetime.fromisoformat(webhook["check:date"])
-    if exception or status == 500:
+    if exception is TimeoutError:
+        assert webhook.get("check:available")
+        assert webhook.get("check:headers:content-type") == "application/json"
+        assert webhook.get("check:headers:content-length") == 10
+    elif exception or status == 500:
         if status == 429:
             # In the case of a 429 status code, the error is on the crawler side and we can't give an availability status.
             # We expect check:available to be None.
@@ -122,7 +132,9 @@ async def test_crawl(setup_catalog, rmock, db, resource, analysis_mock, udata_ur
         assert webhook.get("check:timeout") is False
 
     # CORS headers
-    expect_cors = status and status < 400 and not timeout and not exception
+    expect_cors = (
+        status and status < 400 and not timeout and (not exception or exception is TimeoutError)
+    )
     if expect_cors:
         assert webhook.get("check:cors:status") == 204
         assert webhook.get("check:cors:allow-origin") == "*"
@@ -231,25 +243,37 @@ async def test_deleted_check(setup_catalog, rmock, fake_check, produce_mock):
 
 
 @pytest.mark.parametrize(
-    "head_status,head_headers",
+    "head_status,head_headers,head_exception",
     [
-        pytest.param(501, None, id="invalid_status"),
-        pytest.param(200, {}, id="missing_size_headers"),
+        pytest.param(501, None, None, id="invalid_status"),
+        pytest.param(200, {}, None, id="missing_size_headers"),
         pytest.param(
             200,
             {"content-type": "text/html", "content-length": "247"},
+            None,
             id="waf_html_headers",
         ),
+        pytest.param(None, None, TimeoutError, id="head_timeout"),
     ],
 )
 async def test_switch_head_to_get(
-    setup_catalog, rmock, produce_mock, analysis_mock, db, head_status, head_headers
+    setup_catalog,
+    rmock,
+    produce_mock,
+    analysis_mock,
+    db,
+    head_status,
+    head_headers,
+    head_exception,
 ):
     rurl = RESOURCE_URL
-    head_kwargs = {"status": head_status}
-    if head_headers is not None:
-        head_kwargs["headers"] = head_headers
-    rmock.head(rurl, **head_kwargs)
+    if head_exception:
+        rmock.head(rurl, exception=head_exception)
+    else:
+        head_kwargs = {"status": head_status}
+        if head_headers is not None:
+            head_kwargs["headers"] = head_headers
+        rmock.head(rurl, **head_kwargs)
     rmock.get(rurl, status=200, headers={"content-length": "10"})
     await start_checks(iterations=1)
     assert ("HEAD", URL(rurl)) in rmock.requests
@@ -258,6 +282,19 @@ async def test_switch_head_to_get(
     res = await db.fetchrow("SELECT * FROM checks WHERE url = $1", rurl)
     assert res["status"] == 200
     assert not res["error"]
+
+
+async def test_head_timeout_get_also_fails(setup_catalog, rmock, db, produce_mock):
+    rurl = RESOURCE_URL
+    rmock.head(rurl, exception=TimeoutError)
+    rmock.get(rurl, exception=TimeoutError)
+    await start_checks(iterations=1)
+    assert ("HEAD", URL(rurl)) in rmock.requests
+    assert ("GET", URL(rurl)) in rmock.requests
+
+    res = await db.fetchrow("SELECT * FROM checks WHERE url = $1", rurl)
+    assert res["timeout"] is True
+    assert res["status"] is None
 
 
 async def test_no_switch_head_to_get(setup_catalog, rmock, produce_mock, analysis_mock):

--- a/udata_hydra/crawl/check_resources.py
+++ b/udata_hydra/crawl/check_resources.py
@@ -171,6 +171,15 @@ async def check_resource(
             return RESOURCE_RESPONSE_STATUSES["OK"]
 
     except asyncio.exceptions.TimeoutError:
+        if method == "head":
+            return await check_resource(
+                url,
+                resource,
+                session,
+                force_analysis=force_analysis,
+                method="get",
+                worker_priority=worker_priority,
+            )
         # Process the check data. If it has changed, it will be sent to udata
         await preprocess_check_data(
             dataset_id=resource["dataset_id"],


### PR DESCRIPTION
Hydra crawls resources with **HEAD** by default (5s timeout). Some origins never respond to HEAD while **GET** works, so checks are stored as `timeout: true` with no GET retry.

**Reported case:** resource [Fichier csv](https://www.data.gouv.fr/fr/datasets/longue-vie-aux-objets-acteurs-de-leconomie-circulaire/) (`0e864a1c-b147-4549-a2dd-0b918e70c53c`) — [data.ademe.fr raw URL](https://data.ademe.fr/data-fair/api/v1/datasets/longue-vie-aux-objets-acteurs-de-leconomie-circulaire/raw). ADEME’s server ignores HEAD (timeout >5s); GET responds in <1s. Latest Hydra check: [48299092](https://crawler.data.gouv.fr/api/checks/latest?resource_id=0e864a1c-b147-4549-a2dd-0b918e70c53c) with `timeout: true`.

This change retries with **GET** when HEAD raises `TimeoutError`, consistent with the existing HEAD→GET fallback for incomplete HEAD responses (`has_nice_head`).

## Test plan

- [x] `pytest tests/test_crawl/test_crawl.py::test_switch_head_to_get[head_timeout]`
- [x] `pytest tests/test_crawl/test_crawl.py::test_head_timeout_get_also_fails`
- [ ] After deploy: re-crawl `0e864a1c-b147-4549-a2dd-0b918e70c53c` → `timeout: false`, `status: 200`