### PR TITLE
test: add crawl helpers unit tests

### DIFF
--- a/tests/test_crawl/test_crawl.py
+++ b/tests/test_crawl/test_crawl.py
@@ -245,14 +245,7 @@ async def test_deleted_check(setup_catalog, rmock, fake_check, produce_mock):
 @pytest.mark.parametrize(
     "head_status,head_headers,head_exception",
     [
-        pytest.param(501, None, None, id="invalid_status"),
         pytest.param(200, {}, None, id="missing_size_headers"),
-        pytest.param(
-            200,
-            {"content-type": "text/html", "content-length": "247"},
-            None,
-            id="waf_html_headers",
-        ),
         pytest.param(None, None, TimeoutError, id="head_timeout"),
     ],
 )

--- a/tests/test_crawl/test_crawl.py
+++ b/tests/test_crawl/test_crawl.py
@@ -19,7 +19,6 @@ from udata_hydra import config
 from udata_hydra.analysis.resource import analyse_resource
 from udata_hydra.crawl import start_checks
 from udata_hydra.crawl.check_resources import check_resource
-from udata_hydra.crawl.preprocess_check_data import get_content_type_from_header
 from udata_hydra.db.check import Check
 from udata_hydra.db.resource import Resource
 
@@ -242,31 +241,15 @@ async def test_deleted_check(setup_catalog, rmock, fake_check, produce_mock):
     assert ("HEAD", URL(rurl)) in rmock.requests
 
 
-@pytest.mark.parametrize(
-    "head_status,head_headers,head_exception",
-    [
-        pytest.param(200, {}, None, id="missing_size_headers"),
-        pytest.param(None, None, TimeoutError, id="head_timeout"),
-    ],
-)
-async def test_switch_head_to_get(
+async def test_switch_head_to_get_on_timeout(
     setup_catalog,
     rmock,
     produce_mock,
     analysis_mock,
     db,
-    head_status,
-    head_headers,
-    head_exception,
 ):
     rurl = RESOURCE_URL
-    if head_exception:
-        rmock.head(rurl, exception=head_exception)
-    else:
-        head_kwargs = {"status": head_status}
-        if head_headers is not None:
-            head_kwargs["headers"] = head_headers
-        rmock.head(rurl, **head_kwargs)
+    rmock.head(rurl, exception=TimeoutError)
     rmock.get(rurl, status=200, headers={"content-length": "10"})
     await start_checks(iterations=1)
     assert ("HEAD", URL(rurl)) in rmock.requests
@@ -707,22 +690,6 @@ async def test_recheck_download_only_once(rmock, fake_check, db, produce_mock, s
 
     # GET shouldn't have been called
     assert ("GET", URL(rurl)) not in rmock.requests
-
-
-@pytest.mark.parametrize(
-    "content_type",
-    [
-        # (content type header, parsed content type)
-        ("application/json", "application/json"),
-        ("text/html; charset=utf-8", "text/html"),
-        ("text/html;h5ai=0.20;charset=UTF-8", "text/html"),
-    ],
-)
-async def test_content_type_from_header(content_type):
-    content_type_header, parsed_content_type = content_type
-    assert parsed_content_type == await get_content_type_from_header(
-        {"content-type": content_type_header}
-    )
 
 
 @pytest.mark.parametrize("resource_status", list(Resource.STATUSES.keys()) + [None])

--- a/tests/test_crawl/test_helpers.py
+++ b/tests/test_crawl/test_helpers.py
@@ -1,12 +1,23 @@
 from types import SimpleNamespace
 
 import pytest
+from multidict import CIMultiDict
 
-from udata_hydra.crawl.helpers import SUSPICIOUS_HTML_HEAD_MAX_BYTES, has_nice_head
+from udata_hydra.crawl.helpers import (
+    SUSPICIOUS_HTML_HEAD_MAX_BYTES,
+    convert_headers,
+    fix_surrogates,
+    get_content_type_from_header,
+    has_nice_head,
+    is_valid_status,
+)
 
 
 def _resp(status, headers):
     return SimpleNamespace(status=status, headers=headers)
+
+
+_INVALID_UTF8_FILENAME = b"file-\xff.csv".decode("utf-8", "surrogateescape")
 
 
 @pytest.mark.parametrize(
@@ -30,7 +41,6 @@ def _resp(status, headers):
         ),
         pytest.param(200, {}, False, id="missing_size_headers"),
         pytest.param(501, {"content-length": "10"}, False, id="invalid_status"),
-        pytest.param(429, {"content-length": "10"}, False, id="status_429"),
         pytest.param(
             200,
             {"content-type": "text/html", "content-length": "247"},
@@ -56,3 +66,80 @@ def _resp(status, headers):
 )
 def test_has_nice_head(status, headers, expected):
     assert has_nice_head(_resp(status, headers)) is expected
+
+
+@pytest.mark.parametrize(
+    "status,expected",
+    [
+        pytest.param(None, False, id="none"),
+        pytest.param("", False, id="empty"),
+        pytest.param(200, True, id="ok_200"),
+        pytest.param(399, True, id="ok_399"),
+        pytest.param(400, False, id="client_400"),
+        pytest.param(500, False, id="server_500"),
+        pytest.param(429, None, id="rate_limit_429"),
+        pytest.param("200", True, id="string_status"),
+    ],
+)
+def test_is_valid_status(status, expected):
+    assert is_valid_status(status) is expected
+
+
+@pytest.mark.parametrize(
+    "headers,expected",
+    [
+        pytest.param({"content-type": "application/json"}, "application/json", id="plain"),
+        pytest.param(
+            {"content-type": "text/html; charset=utf-8"},
+            "text/html",
+            id="with_charset",
+        ),
+        pytest.param(
+            {"content-type": "text/html;h5ai=0.20;charset=UTF-8"},
+            "text/html",
+            id="weird_h5ai",
+        ),
+        pytest.param({}, "", id="no_header"),
+        pytest.param({"content-type": "text/csv"}, "text/csv", id="no_semicolon"),
+    ],
+)
+async def test_get_content_type_from_header(headers, expected):
+    assert await get_content_type_from_header(headers) == expected
+
+
+@pytest.mark.parametrize(
+    "headers,expected",
+    [
+        pytest.param({}, {}, id="empty_dict"),
+        pytest.param(None, {}, id="none"),
+        pytest.param(
+            {"Content-LENGTH": "10", "X-Do": "you"},
+            {"content-length": "10", "x-do": "you"},
+            id="lowercase_keys",
+        ),
+        pytest.param(
+            CIMultiDict([("Content-Type", "a"), ("Content-Type", "b")]),
+            {"content-type": "a"},
+            id="cimultidict_first_value",
+        ),
+        pytest.param(
+            {"X-Filename": _INVALID_UTF8_FILENAME},
+            {"x-filename": "file-\ufffd.csv"},
+            id="surrogate_in_value",
+        ),
+    ],
+)
+def test_convert_headers(headers, expected):
+    assert convert_headers(headers) == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        pytest.param("client error", "client error", id="plain_ascii"),
+        pytest.param(42, "42", id="non_str"),
+        pytest.param(_INVALID_UTF8_FILENAME, "file-\ufffd.csv", id="surrogate"),
+    ],
+)
+def test_fix_surrogates(value, expected):
+    assert fix_surrogates(value) == expected

--- a/tests/test_crawl/test_helpers.py
+++ b/tests/test_crawl/test_helpers.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+
+import pytest
+
+from udata_hydra.crawl.helpers import SUSPICIOUS_HTML_HEAD_MAX_BYTES, has_nice_head
+
+
+def _resp(status, headers):
+    return SimpleNamespace(status=status, headers=headers)
+
+
+@pytest.mark.parametrize(
+    "status,headers,expected",
+    [
+        pytest.param(200, {"content-length": "10"}, True, id="valid_content_length"),
+        pytest.param(
+            200,
+            {"last-modified": "Thu, 09 Jan 2020 09:33:37 GMT"},
+            True,
+            id="valid_last_modified_only",
+        ),
+        pytest.param(
+            200,
+            {
+                "content-type": "application/octet-stream",
+                "content-length": "38848259",
+            },
+            True,
+            id="valid_binary_large",
+        ),
+        pytest.param(200, {}, False, id="missing_size_headers"),
+        pytest.param(501, {"content-length": "10"}, False, id="invalid_status"),
+        pytest.param(429, {"content-length": "10"}, False, id="status_429"),
+        pytest.param(
+            200,
+            {"content-type": "text/html", "content-length": "247"},
+            False,
+            id="waf_html_small",
+        ),
+        pytest.param(
+            200,
+            {
+                "content-type": "text/html",
+                "content-length": str(SUSPICIOUS_HTML_HEAD_MAX_BYTES),
+            },
+            True,
+            id="html_at_threshold",
+        ),
+        pytest.param(
+            200,
+            {"content-type": "text/html", "content-length": "not-a-number"},
+            False,
+            id="html_invalid_length",
+        ),
+    ],
+)
+def test_has_nice_head(status, headers, expected):
+    assert has_nice_head(_resp(status, headers)) is expected


### PR DESCRIPTION
**Needs https://github.com/datagouv/hydra/pull/461 to be merged first.**

`crawl/helpers.py` helpers were only exercised indirectly through crawl integration tests, which made edge cases hard to pin down and duplicated coverage.

This PR adds parametrized unit tests for `is_valid_status`, `get_content_type_from_header`, `convert_headers`, and `fix_surrogates`, and trims redundant integration cases now covered at unit level.

## Test plan
- [x] `uv run pytest tests/test_crawl/test_helpers.py`
- [x] `uv run pytest tests/test_crawl/test_crawl.py`