### PR TITLE
chore: better corrupted gzip resilience

### DIFF
--- a/tests/test_utils/test_file.py
+++ b/tests/test_utils/test_file.py
@@ -40,6 +40,35 @@ def test_extract_gzip_writes_to_storage_path(mocker, tmp_path):
         os.remove(extracted.name)
 
 
+def test_extract_gzip_raises_ioerror_on_truncated_file(mocker, tmp_path):
+    mocker.patch("udata_hydra.config.TEMPORARY_DOWNLOAD_FOLDER", str(tmp_path))
+    gz_path = tmp_path / "truncated.csv.gz"
+    gz_path.write_bytes(gzip.compress(b"col\nval")[:10])
+
+    with pytest.raises(IOException, match="Corrupted or truncated gzip file"):
+        extract_gzip(str(gz_path))
+
+
+def test_extract_gzip_raises_ioerror_on_invalid_file(mocker, tmp_path):
+    mocker.patch("udata_hydra.config.TEMPORARY_DOWNLOAD_FOLDER", str(tmp_path))
+    gz_path = tmp_path / "invalid.csv.gz"
+    gz_path.write_bytes(b"this is not gzip at all")
+
+    with pytest.raises(IOException, match="Corrupted or truncated gzip file"):
+        extract_gzip(str(gz_path))
+
+
+async def test_download_resource_corrupted_gzip_raises_ioerror(rmock, mocker, tmp_path):
+    mocker.patch("udata_hydra.config.TEMPORARY_DOWNLOAD_FOLDER", str(tmp_path))
+    url = "http://example.com/file.csv.gz"
+    rmock.get(url, status=200, body=gzip.compress(b"col\nval")[:10])
+
+    with pytest.raises(IOException, match="Corrupted or truncated gzip file"):
+        await download_resource(url=url)
+
+    assert not list(tmp_path.iterdir())
+
+
 async def test_download_resource_rejects_oversized_content_length():
     with pytest.raises(IOException, match="File too large to download"):
         await download_resource(

--- a/udata_hydra/analysis/resource.py
+++ b/udata_hydra/analysis/resource.py
@@ -95,8 +95,8 @@ async def analyse_resource(
             await Resource.update(resource_id, data={"status": "DOWNLOADING_RESOURCE"})
             tmp_file, _ = await download_resource(url, headers, max_size_allowed)
             timer.mark("download-resource")
-        except IOException:
-            dl_analysis["analysis:error"] = "File too large to download"
+        except IOException as e:
+            dl_analysis["analysis:error"] = str(e)
         else:
             await Resource.update(resource_id, data={"status": "ANALYSING_DOWNLOADED_RESOURCE"})
             # Get file size

--- a/udata_hydra/utils/file.py
+++ b/udata_hydra/utils/file.py
@@ -34,12 +34,18 @@ def compute_checksum_from_file(filename: str) -> str:
     return sha1sum.hexdigest()
 
 
-def extract_gzip(file_path: str) -> IO[bytes]:
-    with gzip.open(file_path, "rb") as gz_file:
-        with tempfile.NamedTemporaryFile(
-            dir=storage_path(""), mode="wb", delete=False
-        ) as temp_file:
-            temp_file.write(gz_file.read())
+def extract_gzip(file_path: str, url: str | None = None) -> IO[bytes]:
+    temp_file = None
+    try:
+        with gzip.open(file_path, "rb") as gz_file:
+            with tempfile.NamedTemporaryFile(
+                dir=storage_path(""), mode="wb", delete=False
+            ) as temp_file:
+                temp_file.write(gz_file.read())
+    except (EOFError, gzip.BadGzipFile) as e:
+        if temp_file is not None:
+            os.remove(temp_file.name)
+        raise IOException("Corrupted or truncated gzip file", url=url) from e
     return temp_file
 
 
@@ -97,9 +103,10 @@ async def download_resource(
     ]:
         # It's compressed - extract and determine extension from URL
         gzip_tmp_file_name = tmp_file.name
-        tmp_file = extract_gzip(tmp_file.name)
-        # Remove the gzip original temporary file
-        os.remove(gzip_tmp_file_name)
+        try:
+            tmp_file = extract_gzip(gzip_tmp_file_name, url=url)
+        finally:
+            os.remove(gzip_tmp_file_name)
 
         # Extract any extension before .gz using regex
         match = re.search(r"\.([^.]+)\.gz$", url)

--- a/udata_hydra/utils/file.py
+++ b/udata_hydra/utils/file.py
@@ -44,7 +44,7 @@ def extract_gzip(file_path: str, url: str | None = None) -> IO[bytes]:
                 temp_file.write(gz_file.read())
     except (EOFError, gzip.BadGzipFile) as e:
         if temp_file is not None:
-            os.remove(temp_file.name)
+            Path(temp_file.name).unlink(missing_ok=True)
         raise IOException("Corrupted or truncated gzip file", url=url) from e
     return temp_file
 
@@ -88,11 +88,10 @@ async def download_resource(
         download_error = e
     finally:
         tmp_file.close()
-        if too_large:
-            os.remove(tmp_file.name)
-            raise IOException("File too large to download", url=url)
-        if download_error:
-            os.remove(tmp_file.name)
+        if too_large or download_error:
+            Path(tmp_file.name).unlink(missing_ok=True)
+            if too_large:
+                raise IOException("File too large to download", url=url)
             raise IOException("Error downloading CSV", url=url) from download_error
 
     detected_extension = ""
@@ -106,7 +105,7 @@ async def download_resource(
         try:
             tmp_file = extract_gzip(gzip_tmp_file_name, url=url)
         finally:
-            os.remove(gzip_tmp_file_name)
+            Path(gzip_tmp_file_name).unlink(missing_ok=True)
 
         # Extract any extension before .gz using regex
         match = re.search(r"\.([^.]+)\.gz$", url)

--- a/udata_hydra/utils/file.py
+++ b/udata_hydra/utils/file.py
@@ -2,7 +2,6 @@ import gzip
 import hashlib
 import logging
 import mimetypes
-import os
 import re
 import tempfile
 from pathlib import Path


### PR DESCRIPTION
Currently, hydra fails on gzip extraction on [this resource](https://demo.data.gouv.fr/datasets/regions-administratives-au-1er-janvier-2025-2?resource_id=5df3f76d-3420-4477-a009-81bb015f33b8).

Indeed, the resource seems corrupted
```
curl https://demo-static.data.gouv.fr/resources/regions-administratives-au-1er-janvier-2025-2/20260729-073940/region2025-fra.csv.gz -o test.csv.gz && gunzip test.csv.gz 

gzip: test.csv.gz: unexpected end of file
```

The error wasn't properly handled, leaving the resource with the status `DOWNLOADING_RESOURCE` and nothing stored in extras.
```
Jul 31 14:42:26 dev-03 rq[3423274]: 2026-07-31 14:42:26 dev-03 udata-hydra[3423274] DEBUG Analysis for resource 5df3f76d-3420-4477-a009-81bb015f33b8 in dataset 6a69ae3916c52f25529b3db9
Jul 31 14:42:27 dev-03 rq[3423274]: 2026-07-31 14:42:27 dev-03 rq.worker[3423274] ERROR Worker a62dfb9f5f334ac2a9acb6ca5f523cd1: job aa3820b3-073c-49cd-a89c-c1955a074711: exception raised while executing (udata_hydra.analysis.resource.analyse_resource)
Jul 31 14:42:27 dev-03 rq[3423274]: Traceback (most recent call last):
Jul 31 14:42:27 dev-03 rq[3423274]:   File "/srv/demo-hydra/lib/python3.14/site-packages/rq/worker/base.py", line 1538, in perform_job
Jul 31 14:42:27 dev-03 rq[3423274]:     return_value = job.perform()
Jul 31 14:42:27 dev-03 rq[3423274]:   File "/srv/demo-hydra/lib/python3.14/site-packages/rq/job.py", line 1342, in perform
Jul 31 14:42:27 dev-03 rq[3423274]:     self._result = self._execute()
Jul 31 14:42:27 dev-03 rq[3423274]:                    ~~~~~~~~~~~~~^^
Jul 31 14:42:27 dev-03 rq[3423274]:   File "/srv/demo-hydra/lib/python3.14/site-packages/rq/job.py", line 1405, in _execute
Jul 31 14:42:27 dev-03 rq[3423274]:     coro_result = loop.run_until_complete(result)
Jul 31 14:42:27 dev-03 rq[3423274]:   File "/opt/uv/python/cpython-3.14.5-linux-x86_64-gnu/lib/python3.14/asyncio/base_events.py", line 719, in run_until_complete
Jul 31 14:42:27 dev-03 rq[3423274]:     return future.result()
Jul 31 14:42:27 dev-03 rq[3423274]:            ~~~~~~~~~~~~~^^
Jul 31 14:42:27 dev-03 rq[3423274]:   File "/srv/demo-hydra/lib/python3.14/site-packages/udata_hydra/analysis/resource.py", line 96, in analyse_resource
Jul 31 14:42:27 dev-03 rq[3423274]:     tmp_file, _ = await download_resource(url, headers, max_size_allowed)
Jul 31 14:42:27 dev-03 rq[3423274]:                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jul 31 14:42:27 dev-03 rq[3423274]:   File "/srv/demo-hydra/lib/python3.14/site-packages/udata_hydra/utils/file.py", line 100, in download_resource
Jul 31 14:42:27 dev-03 rq[3423274]:     tmp_file = extract_gzip(tmp_file.name)
Jul 31 14:42:27 dev-03 rq[3423274]:   File "/srv/demo-hydra/lib/python3.14/site-packages/udata_hydra/utils/file.py", line 42, in extract_gzip
Jul 31 14:42:27 dev-03 rq[3423274]:     temp_file.write(gz_file.read())
Jul 31 14:42:27 dev-03 rq[3423274]:                     ~~~~~~~~~~~~^^
Jul 31 14:42:27 dev-03 rq[3423274]:   File "/opt/uv/python/cpython-3.14.5-linux-x86_64-gnu/lib/python3.14/gzip.py", line 349, in read
Jul 31 14:42:27 dev-03 rq[3423274]:     return self._buffer.read(size)
Jul 31 14:42:27 dev-03 rq[3423274]:            ~~~~~~~~~~~~~~~~~^^^^^^
Jul 31 14:42:27 dev-03 rq[3423274]:   File "/opt/uv/python/cpython-3.14.5-linux-x86_64-gnu/lib/python3.14/compression/_common/_streams.py", line 118, in readall
Jul 31 14:42:27 dev-03 rq[3423274]:     while data := self.read(sys.maxsize):
Jul 31 14:42:27 dev-03 rq[3423274]:                   ~~~~~~~~~^^^^^^^^^^^^^
Jul 31 14:42:27 dev-03 rq[3423274]:   File "/opt/uv/python/cpython-3.14.5-linux-x86_64-gnu/lib/python3.14/gzip.py", line 590, in read
Jul 31 14:42:27 dev-03 rq[3423274]:     raise EOFError("Compressed file ended before the "
Jul 31 14:42:27 dev-03 rq[3423274]:                    "end-of-stream marker was reached")
Jul 31 14:42:27 dev-03 rq[3423274]: EOFError: Compressed file ended before the end-of-stream marker was reached
Jul 31 14:42:27 dev-03 rq[3423274]: 2026-07-31 14:42:27 dev-03 rq.job[3423274] DEBUG Job aa3820b3-073c-49cd-a89c-c1955a074711: handling failure: Traceback (most recent call last):
Jul 31 14:42:27 dev-03 rq[3423274]:   File "/srv/demo-hydra/lib/python3.14/site-packages/rq/worker/base.py", line 1538, in perform_job
Jul 31 14:42:27 dev-03 rq[3423274]:     return_value = job.perform()
Jul 31 14:42:27 dev-03 rq[3423274]:   File "/srv/demo-hydra/lib/pytho..
```