### PR TITLE
feat: analyse the single tabular file held in a zip archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Since it's called _hydra_, it also has mythical powers embedded:
 - if the remote resource is tabular (csv or excel-like), convert it to a PostgreSQL table, ready for APIfication, and to parquet to offer another distribution of the data
 - if the remote resource is a geojson, convert it to PMTiles to offer another distribution of the data
 - if the remote resource is parquet, ingest it into a PostgreSQL table for API exposition (similarly to csv/excel resources)
+- if the remote resource is a zip archive holding a single analysable file, extract it and analyse it as its own format
 - if the remote resource is an OGC service (WFS or WMS), fetch capabilities and extract layer metadata
 - probe CORS headers on external resources during crawling
 - send crawl and analysis info to a udata instance
@@ -98,6 +99,7 @@ Workers process three RQ queues in order: **`high`**, **`default`**, **`low`**.
 | `Geojson(...).analyse` | `default`, or `high` via API/CLI | When a GeoJSON file needs parsing |
 | `Parquet(...).analyse` | `default`, or `high` via API/CLI | When a Parquet file needs metadata extraction |
 | `Wfs/Wms.analyse` | `default`, or `high` via API/CLI | When an OGC service needs analysis |
+| `Zip(...).analyse` | `default`, or `high` via API/CLI | When a zip archive needs extracting, before analysing what it holds |
 | `send` | `high` | When hydra informs udata of a resource's changes |
 | `export_parquet` | `low` | After CSV ingest, if `DB_TO_PARQUET` is enabled |
 | `export_geojson_pmtiles` | `low` | After CSV ingest, if `DB_TO_GEOJSON` is enabled and geo columns are detected |

--- a/tests/test_analysis/test_analysis_zip.py
+++ b/tests/test_analysis/test_analysis_zip.py
@@ -56,6 +56,7 @@ async def assert_analysis_failed(db, check: dict, error_fragment: str) -> None:
 
     # the resource must not stay stuck in an analysis status
     resource = await Resource.get(RESOURCE_ID)
+    assert resource is not None
     assert resource["status"] is None
 
     table_name: str = hashlib.md5(check["url"].encode("utf-8")).hexdigest()

--- a/tests/test_analysis/test_analysis_zip.py
+++ b/tests/test_analysis/test_analysis_zip.py
@@ -64,6 +64,21 @@ async def assert_analysis_failed(db, check: dict, error_fragment: str) -> None:
         await db.fetch(f'SELECT * FROM "{table_name}"')
 
 
+async def assert_not_analysed(db, check: dict) -> None:
+    """Holding nothing analysable is not a failure: no error must be recorded"""
+    res = await db.fetchrow("SELECT * FROM checks")
+    assert res["parsing_error"] is None
+    assert res["parsing_table"] is None
+
+    resource = await Resource.get(RESOURCE_ID)
+    assert resource is not None
+    assert resource["status"] is None
+
+    table_name: str = hashlib.md5(check["url"].encode("utf-8")).hexdigest()
+    with pytest.raises(UndefinedTableError):
+        await db.fetch(f'SELECT * FROM "{table_name}"')
+
+
 async def test_analyse_zip_with_single_csv(setup_catalog, rmock, db, fake_check, produce_mock):
     check = await fake_check(headers={"content-type": "application/zip"})
     await analyse_zip(check, rmock, make_zip({"data.csv": CSV_CONTENT}))
@@ -100,17 +115,26 @@ async def test_analyse_zip_ignores_macos_resource_fork(
 
 
 async def test_analyse_zip_with_several_csv(setup_catalog, rmock, db, fake_check, produce_mock):
+    """A dataset split in several csv is not a broken resource, we just leave it alone"""
     check = await fake_check(headers={"content-type": "application/zip"})
     await analyse_zip(check, rmock, make_zip({"first.csv": CSV_CONTENT, "second.csv": CSV_CONTENT}))
-    await assert_analysis_failed(db, check, "Several analysable files")
+    await assert_not_analysed(db, check)
 
 
 async def test_analyse_zip_without_analysable_file(
-    setup_catalog, rmock, db, fake_check, produce_mock
+    setup_catalog, rmock, db, fake_check, produce_mock, mocker
 ):
+    """A shapefile bundle or a set of documents is not analysable, and not a failure either:
+    udata must not be told the parsing failed"""
+    notify_udata = mocker.patch(
+        "udata_hydra.data_formats.zip.helpers.notify_udata", new=mocker.AsyncMock()
+    )
     check = await fake_check(headers={"content-type": "application/zip"})
-    await analyse_zip(check, rmock, make_zip({"doc.pdf": b"%PDF-1.4", "logo.png": b"\x89PNG"}))
-    await assert_analysis_failed(db, check, "No analysable file")
+    await analyse_zip(
+        check, rmock, make_zip({"parcels.shp": b"\x00\x00'\n", "parcels.dbf": b"\x03d"})
+    )
+    await assert_not_analysed(db, check)
+    notify_udata.assert_not_awaited()
 
 
 async def test_analyse_zip_corrupted_archive(setup_catalog, rmock, db, fake_check, produce_mock):

--- a/tests/test_analysis/test_analysis_zip.py
+++ b/tests/test_analysis/test_analysis_zip.py
@@ -9,7 +9,8 @@ from asyncpg.exceptions import UndefinedTableError
 from tests.conftest import RESOURCE_ID, SIMPLE_CSV_CONTENT
 from udata_hydra.analysis.helpers import download_from_check
 from udata_hydra.analysis.resource import analyse_resource
-from udata_hydra.data_formats import Csv, Csvgz, Zip
+from udata_hydra.data_formats import Csv, Csvgz, Geojson, Parquet, Xls, Xlsx, Zip
+from udata_hydra.data_formats.data_format import DataFormat
 from udata_hydra.data_formats.detect import detect_data_format_from_check_or_catalog
 from udata_hydra.db.resource import Resource
 from udata_hydra.utils import storage_path
@@ -25,12 +26,28 @@ DVF_LIKE_CONTENT: bytes = "\n".join(
 ).encode("utf-8")
 
 
-def make_zip(members: dict[str, bytes]) -> bytes:
+def make_zip(members: dict[str, bytes], compression: int = zipfile.ZIP_DEFLATED) -> bytes:
     buffer = BytesIO()
-    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+    with zipfile.ZipFile(buffer, "w", compression) as archive:
         for name, content in members.items():
             archive.writestr(name, content)
     return buffer.getvalue()
+
+
+def make_zip_with_corrupted_member() -> bytes:
+    """Central directory intact, payload damaged: the archive only blows up on the CRC check, at
+    the very end of the extraction, once a temporary file has been written.
+
+    The member is stored rather than deflated so that the failure is exactly that one: damaging a
+    deflate stream raises from zlib instead, depending on which byte was hit."""
+    name: str = "data.csv"
+    archive = bytearray(make_zip({name: CSV_CONTENT * 10}, compression=zipfile.ZIP_STORED))
+    with zipfile.ZipFile(BytesIO(bytes(archive))) as reader:
+        member: zipfile.ZipInfo = reader.infolist()[0]
+        # a stored payload sits right after its local header: 30 fixed bytes, name, extra field
+        payload_start: int = member.header_offset + 30 + len(member.filename) + len(member.extra)
+    archive[payload_start] ^= 0xFF
+    return bytes(archive)
 
 
 async def analyse_zip(check: dict, rmock, body: bytes) -> None:
@@ -46,6 +63,11 @@ async def assert_analysed(db, check: dict, expected_lines: int) -> None:
     res = await db.fetchrow("SELECT * FROM checks")
     assert res["parsing_error"] is None
     assert res["parsing_table"] == table_name
+
+    # the resource must not stay stuck in an analysis status
+    resource = await Resource.get(RESOURCE_ID)
+    assert resource is not None
+    assert resource["status"] is None
 
 
 async def assert_analysis_failed(db, check: dict, error_fragment: str) -> None:
@@ -137,19 +159,53 @@ async def test_analyse_zip_without_analysable_file(
     notify_udata.assert_not_awaited()
 
 
-async def test_analyse_zip_corrupted_archive(setup_catalog, rmock, db, fake_check, produce_mock):
+async def test_analyse_zip_does_not_recurse_into_a_nested_zip(
+    setup_catalog, rmock, db, fake_check, produce_mock
+):
+    """The 42.zip dead end: an archive is never an analysable member of another archive"""
+    check = await fake_check(headers={"content-type": "application/zip"})
+    await analyse_zip(check, rmock, make_zip({"inner.zip": make_zip({"data.csv": CSV_CONTENT})}))
+    await assert_not_analysed(db, check)
+
+
+@pytest.mark.parametrize("compression", (zipfile.ZIP_LZMA, zipfile.ZIP_BZIP2))
+async def test_analyse_zip_refuses_unbounded_compression(
+    setup_catalog, rmock, db, fake_check, produce_mock, compression
+):
+    """zipfile only bounds what it decompresses for stored and deflated members: with lzma or
+    bzip2 it decompresses a whole chunk in one go, so a member lying about its file_size would
+    allocate gigabytes before any cap of ours can apply"""
+    check = await fake_check(headers={"content-type": "application/zip"})
+    await analyse_zip(check, rmock, make_zip({"data.csv": CSV_CONTENT}, compression=compression))
+    await assert_analysis_failed(db, check, "Unsupported compression method")
+
+
+@pytest.mark.parametrize("compression", (zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED))
+async def test_analyse_zip_accepts_bounded_compression(
+    setup_catalog, rmock, db, fake_check, produce_mock, compression
+):
+    check = await fake_check(headers={"content-type": "application/zip"})
+    await analyse_zip(check, rmock, make_zip({"data.csv": CSV_CONTENT}, compression=compression))
+    await assert_analysed(db, check, expected_lines=2)
+
+
+async def test_analyse_zip_corrupted_archive(
+    setup_catalog, rmock, db, fake_check, produce_mock, mocker
+):
+    """A real failure, unlike an archive holding nothing analysable, must reach udata"""
+    notify_udata = mocker.patch(
+        "udata_hydra.data_formats.zip.helpers.notify_udata", new=mocker.AsyncMock()
+    )
     check = await fake_check(headers={"content-type": "application/zip"})
     truncated: bytes = make_zip({"data.csv": CSV_CONTENT})[:40]
     await analyse_zip(check, rmock, truncated)
     await assert_analysis_failed(db, check, "not a zip file")
+    notify_udata.assert_awaited_once()
 
 
 async def test_analyse_zip_corrupted_member(setup_catalog, rmock, db, fake_check, produce_mock):
-    """Central directory intact, compressed data damaged: it only blows up while extracting"""
     check = await fake_check(headers={"content-type": "application/zip"})
-    archive = bytearray(make_zip({"data.csv": CSV_CONTENT * 10}))
-    archive[60:80] = b"\x00" * 20
-    await analyse_zip(check, rmock, bytes(archive))
+    await analyse_zip(check, rmock, make_zip_with_corrupted_member())
     await assert_analysis_failed(db, check, "Bad CRC-32")
 
 
@@ -163,20 +219,72 @@ async def test_analyse_zip_member_too_large(
     await assert_analysis_failed(db, check, "too large")
 
 
-@pytest.mark.parametrize("fails", (False, True))
+@pytest.mark.parametrize(
+    "body,refuse_on_size",
+    (
+        (make_zip({"data.csv": CSV_CONTENT}), False),
+        (make_zip({"data.csv": CSV_CONTENT}), True),
+        (make_zip_with_corrupted_member(), False),
+    ),
+    ids=("analysed", "refused-before-extraction", "failed-mid-extraction"),
+)
 async def test_analyse_zip_leaves_no_file_behind(
-    setup_catalog, rmock, db, fake_check, produce_mock, mocker, fails
+    setup_catalog, rmock, db, fake_check, produce_mock, mocker, body, refuse_on_size
 ):
-    """Neither the archive nor the extracted member should survive the analysis, failed or not"""
-    if fails:
+    """Neither the archive nor the extracted member should survive the analysis, whether it
+    succeeds, is refused before anything is written, or blows up halfway through the extraction"""
+    if refuse_on_size:
         mocker.patch.object(Csv, "max_filesize_allowed", 10)
     check = await fake_check(headers={"content-type": "application/zip"})
     download_folder: Path = storage_path("")
     before: set[str] = {path.name for path in download_folder.iterdir()}
 
-    await analyse_zip(check, rmock, make_zip({"data.csv": CSV_CONTENT}))
+    await analyse_zip(check, rmock, body)
 
     assert {path.name for path in download_folder.iterdir()} == before
+
+
+@pytest.mark.parametrize(
+    "member_name,expected_format",
+    (
+        ("data.csv", Csv),
+        ("data.tsv", Csv),
+        ("data.xls", Xls),
+        ("data.xlsx", Xlsx),
+        ("data.geojson", Geojson),
+        ("data.parquet", Parquet),
+        ("data.txt", Csv),
+    ),
+)
+async def test_extract_hands_the_member_to_its_own_format(
+    setup_catalog, rmock, db, fake_check, produce_mock, member_name, expected_format
+):
+    """The extension table is what routes a member to its analyser: an inverted entry would have
+    a xls analysed as a xlsx without anything failing"""
+    check = await fake_check(headers={"content-type": "application/zip"})
+    rmock.get(check["url"], status=200, body=make_zip({member_name: CSV_CONTENT}))
+    archive: DataFormat = await download_from_check(check, Zip)
+    assert isinstance(archive, Zip)
+
+    extracted: DataFormat | None = archive.extract(check)
+
+    assert extracted is not None
+    assert type(extracted) is expected_format
+    archive.path.unlink(missing_ok=True)
+    extracted.path.unlink()
+
+
+@pytest.mark.parametrize("filename", ("catalog.xls", "catalog.xlsx"))
+async def test_analyse_zip_with_a_single_excel_file(
+    setup_catalog, rmock, db, fake_check, produce_mock, filename
+):
+    """Extracted members are named after a temporary file: the analysers must cope with a path
+    that carries no extension of its own"""
+    check = await fake_check(headers={"content-type": "application/zip"})
+    with open(f"tests/data/{filename}", "rb") as f:
+        content: bytes = f.read()
+    await analyse_zip(check, rmock, make_zip({filename: content}))
+    await assert_analysed(db, check, expected_lines=2)
 
 
 async def test_analyse_resource_extracts_zip(setup_catalog, rmock, db, fake_check, produce_mock):
@@ -196,8 +304,13 @@ async def test_analyse_resource_extracts_zip(setup_catalog, rmock, db, fake_chec
         ("txt.zip", "application/zip", Zip),
         ("zip", "application/octet-stream", Zip),
         (None, "application/zip", Zip),
+        (None, "application/x-zip-compressed", Zip),
         # regression: "gzip".endswith("zip"), a gzipped csv must not be taken for an archive
         ("csv.gz", "application/gzip", Csvgz),
+        # regression: an xlsx IS a zip container and is often served as such, the catalog format
+        # of another format must not lose to the zip mime type
+        ("xlsx", "application/zip", Xlsx),
+        ("xlsx", "application/x-zip-compressed", Xlsx),
     ),
 )
 async def test_detect_zip_from_check_or_catalog(

--- a/tests/test_analysis/test_analysis_zip.py
+++ b/tests/test_analysis/test_analysis_zip.py
@@ -1,0 +1,183 @@
+import hashlib
+import zipfile
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from asyncpg.exceptions import UndefinedTableError
+
+from tests.conftest import RESOURCE_ID, SIMPLE_CSV_CONTENT
+from udata_hydra.analysis.helpers import download_from_check
+from udata_hydra.analysis.resource import analyse_resource
+from udata_hydra.data_formats import Csv, Csvgz, Zip
+from udata_hydra.data_formats.detect import detect_data_format_from_check_or_catalog
+from udata_hydra.db.resource import Resource
+from udata_hydra.utils import storage_path
+
+pytestmark = pytest.mark.asyncio
+
+CSV_CONTENT: bytes = SIMPLE_CSV_CONTENT.encode("utf-8")
+
+# DVF, the resource this format was built for, ships its data as a pipe separated `.txt`
+DVF_LIKE_CONTENT: bytes = "\n".join(
+    ["Identifiant de document|Date mutation|Valeur fonciere|Commune"]
+    + [f"{i:06d}|07/01/2025|{100000 + i * 1000},00|FARGES" for i in range(20)]
+).encode("utf-8")
+
+
+def make_zip(members: dict[str, bytes]) -> bytes:
+    buffer = BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name, content in members.items():
+            archive.writestr(name, content)
+    return buffer.getvalue()
+
+
+async def analyse_zip(check: dict, rmock, body: bytes) -> None:
+    rmock.get(check["url"], status=200, body=body)
+    file = await download_from_check(check, Zip)
+    await file.analyse(check=check)
+
+
+async def assert_analysed(db, check: dict, expected_lines: int) -> None:
+    table_name: str = hashlib.md5(check["url"].encode("utf-8")).hexdigest()
+    rows = list(await db.fetch(f'SELECT * FROM "{table_name}"'))
+    assert len(rows) == expected_lines
+    res = await db.fetchrow("SELECT * FROM checks")
+    assert res["parsing_error"] is None
+    assert res["parsing_table"] == table_name
+
+
+async def assert_analysis_failed(db, check: dict, error_fragment: str) -> None:
+    res = await db.fetchrow("SELECT * FROM checks")
+    assert res["parsing_error"].startswith("zip_extraction:")
+    assert error_fragment in res["parsing_error"]
+    assert res["parsing_table"] is None
+
+    # the resource must not stay stuck in an analysis status
+    resource = await Resource.get(RESOURCE_ID)
+    assert resource["status"] is None
+
+    table_name: str = hashlib.md5(check["url"].encode("utf-8")).hexdigest()
+    with pytest.raises(UndefinedTableError):
+        await db.fetch(f'SELECT * FROM "{table_name}"')
+
+
+async def test_analyse_zip_with_single_csv(setup_catalog, rmock, db, fake_check, produce_mock):
+    check = await fake_check(headers={"content-type": "application/zip"})
+    await analyse_zip(check, rmock, make_zip({"data.csv": CSV_CONTENT}))
+    await assert_analysed(db, check, expected_lines=2)
+
+
+async def test_analyse_zip_with_single_txt(setup_catalog, rmock, db, fake_check, produce_mock):
+    """The DVF case: a pipe separated .txt is the only file of the archive"""
+    check = await fake_check(headers={"content-type": "application/zip"})
+    await analyse_zip(check, rmock, make_zip({"ValeursFoncieres-2025.txt": DVF_LIKE_CONTENT}))
+    await assert_analysed(db, check, expected_lines=20)
+
+
+async def test_analyse_zip_ignores_readme(setup_catalog, rmock, db, fake_check, produce_mock):
+    """A .txt next to a .csv is a readme, not the data"""
+    check = await fake_check(headers={"content-type": "application/zip"})
+    await analyse_zip(
+        check, rmock, make_zip({"data.csv": CSV_CONTENT, "readme.txt": b"some documentation"})
+    )
+    await assert_analysed(db, check, expected_lines=2)
+
+
+async def test_analyse_zip_ignores_macos_resource_fork(
+    setup_catalog, rmock, db, fake_check, produce_mock
+):
+    """Archives zipped on macOS shadow every file with a __MACOSX/._name entry"""
+    check = await fake_check(headers={"content-type": "application/zip"})
+    await analyse_zip(
+        check,
+        rmock,
+        make_zip({"data.csv": CSV_CONTENT, "__MACOSX/._data.csv": b"\x00\x05\x16\x07"}),
+    )
+    await assert_analysed(db, check, expected_lines=2)
+
+
+async def test_analyse_zip_with_several_csv(setup_catalog, rmock, db, fake_check, produce_mock):
+    check = await fake_check(headers={"content-type": "application/zip"})
+    await analyse_zip(check, rmock, make_zip({"first.csv": CSV_CONTENT, "second.csv": CSV_CONTENT}))
+    await assert_analysis_failed(db, check, "Several analysable files")
+
+
+async def test_analyse_zip_without_analysable_file(
+    setup_catalog, rmock, db, fake_check, produce_mock
+):
+    check = await fake_check(headers={"content-type": "application/zip"})
+    await analyse_zip(check, rmock, make_zip({"doc.pdf": b"%PDF-1.4", "logo.png": b"\x89PNG"}))
+    await assert_analysis_failed(db, check, "No analysable file")
+
+
+async def test_analyse_zip_corrupted_archive(setup_catalog, rmock, db, fake_check, produce_mock):
+    check = await fake_check(headers={"content-type": "application/zip"})
+    truncated: bytes = make_zip({"data.csv": CSV_CONTENT})[:40]
+    await analyse_zip(check, rmock, truncated)
+    await assert_analysis_failed(db, check, "not a zip file")
+
+
+async def test_analyse_zip_corrupted_member(setup_catalog, rmock, db, fake_check, produce_mock):
+    """Central directory intact, compressed data damaged: it only blows up while extracting"""
+    check = await fake_check(headers={"content-type": "application/zip"})
+    archive = bytearray(make_zip({"data.csv": CSV_CONTENT * 10}))
+    archive[60:80] = b"\x00" * 20
+    await analyse_zip(check, rmock, bytes(archive))
+    await assert_analysis_failed(db, check, "Bad CRC-32")
+
+
+async def test_analyse_zip_member_too_large(
+    setup_catalog, rmock, db, fake_check, produce_mock, mocker
+):
+    """A member is refused on the limit of the format it would be analysed with"""
+    mocker.patch.object(Csv, "max_filesize_allowed", 10)
+    check = await fake_check(headers={"content-type": "application/zip"})
+    await analyse_zip(check, rmock, make_zip({"data.csv": CSV_CONTENT}))
+    await assert_analysis_failed(db, check, "too large")
+
+
+@pytest.mark.parametrize("fails", (False, True))
+async def test_analyse_zip_leaves_no_file_behind(
+    setup_catalog, rmock, db, fake_check, produce_mock, mocker, fails
+):
+    """Neither the archive nor the extracted member should survive the analysis, failed or not"""
+    if fails:
+        mocker.patch.object(Csv, "max_filesize_allowed", 10)
+    check = await fake_check(headers={"content-type": "application/zip"})
+    download_folder: Path = storage_path("")
+    before: set[str] = {path.name for path in download_folder.iterdir()}
+
+    await analyse_zip(check, rmock, make_zip({"data.csv": CSV_CONTENT}))
+
+    assert {path.name for path in download_folder.iterdir()} == before
+
+
+async def test_analyse_resource_extracts_zip(setup_catalog, rmock, db, fake_check, produce_mock):
+    """The whole path: format detected from the catalog, download, extraction, csv analysis"""
+    await Resource.update(RESOURCE_ID, {"format": "txt.zip"})
+    check = await fake_check(headers={"content-type": "application/zip"})
+    rmock.get(check["url"], status=200, body=make_zip({"data.txt": DVF_LIKE_CONTENT}))
+
+    await analyse_resource(check=check, last_check=None)
+
+    await assert_analysed(db, check, expected_lines=20)
+
+
+@pytest.mark.parametrize(
+    "resource_format,content_type,expected",
+    (
+        ("txt.zip", "application/zip", Zip),
+        ("zip", "application/octet-stream", Zip),
+        (None, "application/zip", Zip),
+        # regression: "gzip".endswith("zip"), a gzipped csv must not be taken for an archive
+        ("csv.gz", "application/gzip", Csvgz),
+    ),
+)
+async def test_detect_zip_from_check_or_catalog(
+    setup_catalog, fake_check, resource_format, content_type, expected
+):
+    await Resource.update(RESOURCE_ID, {"format": resource_format})
+    check = await fake_check(headers={"content-type": content_type})
+    assert await detect_data_format_from_check_or_catalog(check) is expected

--- a/udata_hydra/config_default.toml
+++ b/udata_hydra/config_default.toml
@@ -65,6 +65,8 @@ MAX_FILESIZE_ALLOWED.geojson = 104857600
 MAX_FILESIZE_ALLOWED.parquet = 52428800
 MAX_FILESIZE_ALLOWED.wms = 1048576     # 1 MB
 MAX_FILESIZE_ALLOWED.wfs = 1048576     # 1 MB
+# applies to the archive itself; once extracted, the file must fit its own format's limit
+MAX_FILESIZE_ALLOWED.zip = 104857600
 
 DEFAULT_MAX_FILESIZE_ALLOWED = 52428800
 

--- a/udata_hydra/data_formats/__init__.py
+++ b/udata_hydra/data_formats/__init__.py
@@ -5,3 +5,4 @@ from udata_hydra.data_formats.ogc import Ogc, Wfs, Wms  # noqa
 from udata_hydra.data_formats.parquet import Parquet  # noqa
 from udata_hydra.data_formats.pmtiles import PMTiles  # noqa
 from udata_hydra.data_formats.table import Table  # noqa
+from udata_hydra.data_formats.zip import Zip  # noqa

--- a/udata_hydra/data_formats/detect.py
+++ b/udata_hydra/data_formats/detect.py
@@ -16,9 +16,15 @@ async def detect_data_format_from_check_or_catalog(check: dict) -> type[DataForm
             "SELECT format FROM catalog WHERE resource_id = $1", f"{check['resource_id']}"
         )
     resource_format = row["format"] if row is not None else None
+
+    # A "*.zip" catalog format wins over another format's mime type: an archive announced as such
+    # stays an archive whatever it is served as. The reverse would be wrong, hence the two halves:
+    # an xlsx is a zip container, so a resource declared xlsx and served as "application/zip" must
+    # keep being analysed as an xlsx. Zip only gets to win on its mime type below, last.
+    if Zip.detect_from_catalog_format(resource_format):
+        return Zip
+
     for fmt in [
-        # first, so that a "*.zip" catalog format wins over another format's mime type
-        Zip,
         Csv,
         Csvgz,
         Xls,
@@ -27,6 +33,7 @@ async def detect_data_format_from_check_or_catalog(check: dict) -> type[DataForm
         Parquet,
         Wfs,
         Wms,
+        Zip,
     ]:
         if fmt.detect_from_check(
             check, resource_format=resource_format

--- a/udata_hydra/data_formats/detect.py
+++ b/udata_hydra/data_formats/detect.py
@@ -6,6 +6,7 @@ from udata_hydra.data_formats.data_format import DataFormat
 from udata_hydra.data_formats.geojson import Geojson
 from udata_hydra.data_formats.ogc import Wfs, Wms
 from udata_hydra.data_formats.parquet import Parquet
+from udata_hydra.data_formats.zip import Zip
 
 
 async def detect_data_format_from_check_or_catalog(check: dict) -> type[DataFormat] | None:
@@ -16,6 +17,8 @@ async def detect_data_format_from_check_or_catalog(check: dict) -> type[DataForm
         )
     resource_format = row["format"] if row is not None else None
     for fmt in [
+        # first, so that a "*.zip" catalog format wins over another format's mime type
+        Zip,
         Csv,
         Csvgz,
         Xls,

--- a/udata_hydra/data_formats/zip/__init__.py
+++ b/udata_hydra/data_formats/zip/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import shutil
 import zipfile
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -32,6 +33,12 @@ DATA_EXTENSIONS: dict[str, type[DataFormat]] = {
 FALLBACK_EXTENSIONS: dict[str, type[DataFormat]] = {".txt": Csv}
 
 EXTRACTION_CHUNK_SIZE = 1024 * 1024
+
+# The only two methods whose output zipfile bounds while decompressing: it passes our read size
+# down to the deflate decompressor, and a stored member is copied as is. For bzip2 and lzma it
+# hands the whole compressed chunk over and truncates the result afterwards, so a member lying
+# about its file_size would have allocated gigabytes before we get a chance to count anything.
+SAFE_COMPRESSION_METHODS = {zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED}
 
 # Member names end up in parsing_error, which we send to udata: never relay an arbitrary long string
 MAX_MEMBER_NAME_LENGTH = 100
@@ -107,39 +114,33 @@ class Zip(DataFormat):
         self, archive: zipfile.ZipFile, member: zipfile.ZipInfo, max_size: int, check: dict
     ) -> Path:
         """Write a member of the archive next to it, without ever letting it grow over :max_size:"""
-        too_large = self.io_error(
-            f"Extracted file too large: {member.filename[:MAX_MEMBER_NAME_LENGTH]}", check
-        )
-        # This is what caps a decompression bomb: zipfile stops decompressing at the announced
-        # file_size (and fails the CRC check if the content does not match it), so an archive
-        # cannot deliver more bytes than it declares here.
+        if member.compress_type not in SAFE_COMPRESSION_METHODS:
+            raise self.io_error(
+                f"Unsupported compression method in the zip archive: {member.compress_type}", check
+            )
+
+        # Together with the check above, this is what caps a decompression bomb: for those two
+        # methods zipfile stops decompressing at the announced file_size (and fails the CRC check
+        # if the content does not match it), so an archive cannot deliver more bytes than it
+        # declares here.
         if member.file_size > max_size:
-            raise too_large
+            raise self.io_error(
+                f"Extracted file too large: {member.filename[:MAX_MEMBER_NAME_LENGTH]}", check
+            )
 
         destination = NamedTemporaryFile(dir=storage_path(""), delete=False)
         try:
-            # never `archive.extract()`: the member name is attacker-controlled and could escape the
-            # download folder ("../../etc/passwd"), while a generated name cannot
-            with archive.open(member) as source:
-                written = 0
-                while chunk := source.read(EXTRACTION_CHUNK_SIZE):
-                    # belt and braces: the check above holds as long as zipfile honours file_size,
-                    # counting what we actually write holds regardless
-                    written += len(chunk)
-                    if written > max_size:
-                        raise too_large
-                    destination.write(chunk)
-        except IOException:
-            Path(destination.name).unlink(missing_ok=True)
-            raise
+            # never `archive.extract()`: it would write the member under the name the archive
+            # chose, wherever that name points to inside the shared download folder, while the
+            # rest of the pipeline expects the generated one
+            with destination, archive.open(member) as source:
+                shutil.copyfileobj(source, destination, EXTRACTION_CHUNK_SIZE)
         except Exception as e:
             Path(destination.name).unlink(missing_ok=True)
             raise self.io_error(
                 f"Could not extract {member.filename[:MAX_MEMBER_NAME_LENGTH]} from the zip archive",
                 check,
             ) from e
-        finally:
-            destination.close()
 
         return Path(destination.name)
 
@@ -147,6 +148,11 @@ class Zip(DataFormat):
         """Extract the single analysable file of the archive, as the format able to analyse it,
         or None if the archive holds nothing we know how to analyse"""
         try:
+            # Opening an archive reads its whole central directory into memory, one ZipInfo per
+            # entry and no cap: an archive made of nothing but entry headers costs roughly ten
+            # times its own size in RSS. Bounding that would mean parsing the end of central
+            # directory record ourselves before handing the file to zipfile — the amplification
+            # stays bounded by MAX_FILESIZE_ALLOWED.zip, so we live with it.
             archive = zipfile.ZipFile(self.path)
         except Exception as e:
             # BadZipFile, but also RuntimeError (encrypted archive), NotImplementedError (unsupported

--- a/udata_hydra/data_formats/zip/__init__.py
+++ b/udata_hydra/data_formats/zip/__init__.py
@@ -73,9 +73,12 @@ class Zip(DataFormat):
         )
 
     def select_member(
-        self, archive: zipfile.ZipFile, check: dict
-    ) -> tuple[zipfile.ZipInfo, type[DataFormat]]:
-        """Pick the one file of the archive we know how to analyse, if there is exactly one."""
+        self, archive: zipfile.ZipFile
+    ) -> tuple[zipfile.ZipInfo, type[DataFormat]] | None:
+        """Pick the one file of the archive we know how to analyse, or None if there isn't exactly
+        one. An archive of shapefiles, of pictures, or a dataset split in several csv is not a
+        broken resource: there is simply nothing for us to analyse, and saying so as a parsing
+        error would report a failure where hydra never committed to analysing anything."""
         members: list[zipfile.ZipInfo] = [
             info for info in archive.infolist() if is_data_member(info)
         ]
@@ -91,10 +94,12 @@ class Zip(DataFormat):
                 break
 
         if not candidates:
-            raise self.io_error("No analysable file in the zip archive", check)
+            log.debug("No analysable file in the zip archive, skipping.")
+            return None
         if len(candidates) > 1:
             names = ", ".join(info.filename[:MAX_MEMBER_NAME_LENGTH] for info, _ in candidates[:5])
-            raise self.io_error(f"Several analysable files in the zip archive: {names}", check)
+            log.debug(f"Several analysable files in the zip archive, skipping: {names}")
+            return None
 
         return candidates[0]
 
@@ -138,8 +143,9 @@ class Zip(DataFormat):
 
         return Path(destination.name)
 
-    def extract(self, check: dict) -> DataFormat:
-        """Extract the single analysable file of the archive, as the format able to analyse it"""
+    def extract(self, check: dict) -> DataFormat | None:
+        """Extract the single analysable file of the archive, as the format able to analyse it,
+        or None if the archive holds nothing we know how to analyse"""
         try:
             archive = zipfile.ZipFile(self.path)
         except Exception as e:
@@ -148,7 +154,10 @@ class Zip(DataFormat):
             raise self.io_error("Could not open the zip archive", check) from e
 
         with archive:
-            member, data_format = self.select_member(archive, check)
+            selected = self.select_member(archive)
+            if selected is None:
+                return None
+            member, data_format = selected
             extracted: Path = self.extract_member(
                 archive, member, data_format.max_filesize_allowed, check
             )
@@ -164,15 +173,18 @@ class Zip(DataFormat):
         resource_id: str = str(check["resource_id"])
         resource: Record | None = await Resource.update(resource_id, {"status": "EXTRACTING_ZIP"})
 
+        file: DataFormat | None = None
         try:
-            file: DataFormat = self.extract(check)
+            file = self.extract(check)
         except IOException as e:
             check = await handle_parse_exception(e, None, check)  # type: ignore[assignment]
             await helpers.notify_udata(resource, check)
-            await Resource.update(resource_id, {"status": None})
-            return
         finally:
             self.path.unlink(missing_ok=True)
+
+        if file is None:
+            await Resource.update(resource_id, {"status": None})
+            return
 
         log.debug(f"Extracted {file.file_name} from archive, analysing it as {type(file).__name__}")
         await file.analyse(check=check)

--- a/udata_hydra/data_formats/zip/__init__.py
+++ b/udata_hydra/data_formats/zip/__init__.py
@@ -1,0 +1,178 @@
+import logging
+import zipfile
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from asyncpg import Record
+
+from udata_hydra import config
+from udata_hydra.analysis import helpers
+from udata_hydra.data_formats.csv_like import Csv, Xls, Xlsx
+from udata_hydra.data_formats.data_format import DataFormat
+from udata_hydra.data_formats.geojson import Geojson
+from udata_hydra.data_formats.parquet import Parquet
+from udata_hydra.db.resource import Resource
+from udata_hydra.utils import IOException, handle_parse_exception, storage_path
+
+log = logging.getLogger("udata-hydra")
+
+# Extensions that only ever carry data, mapped to the format that knows how to analyse them.
+# `.zip` is deliberately absent: this is what makes a zip of zips (the 42.zip bomb) a dead end.
+DATA_EXTENSIONS: dict[str, type[DataFormat]] = {
+    ".csv": Csv,
+    ".tsv": Csv,
+    ".xls": Xls,
+    ".xlsx": Xlsx,
+    ".geojson": Geojson,
+    ".parquet": Parquet,
+}
+
+# A `.txt` is worth analysing (csv-detective sniffs the separator, DVF ships its data that way), but
+# it is also how a readme is named: only consider those when the archive holds no proper data file.
+FALLBACK_EXTENSIONS: dict[str, type[DataFormat]] = {".txt": Csv}
+
+EXTRACTION_CHUNK_SIZE = 1024 * 1024
+
+# Member names end up in parsing_error, which we send to udata: never relay an arbitrary long string
+MAX_MEMBER_NAME_LENGTH = 100
+
+
+def is_data_member(info: zipfile.ZipInfo) -> bool:
+    """Directories and macOS resource forks carry no data, but the forks (__MACOSX/._name) do carry
+    the extension of the file they shadow, so they would be counted as candidates."""
+    name = Path(info.filename)
+    return not info.is_dir() and "__MACOSX" not in name.parts and not name.name.startswith("._")
+
+
+class Zip(DataFormat):
+    """A zip archive holding a single analysable file.
+
+    The archive itself carries no data: we extract that file and hand it over to the format that
+    knows how to analyse it, so the rest of the pipeline never has to know it came from an archive.
+    """
+
+    standard_mime_type = "application/zip"
+    # not "application/octet-stream", which already belongs to Csvgz
+    valid_mime_types = {standard_mime_type, "application/x-zip-compressed"}
+    max_filesize_allowed = int(config.MAX_FILESIZE_ALLOWED["zip"])
+    further_analysis = True
+
+    @classmethod
+    def detect_from_catalog_format(cls, format: str | None) -> bool:
+        # udata declares archives either as "zip" or as "<inner extension>.zip", e.g. "txt.zip".
+        # Matching on ".zip" and not "zip" keeps "gzip" out.
+        return format is not None and (format == "zip" or format.endswith(".zip"))
+
+    def io_error(self, message: str, check: dict) -> IOException:
+        return IOException(
+            message,
+            step="zip_extraction",
+            resource_id=self.resource_id,
+            url=check["url"],
+            check_id=check["id"],
+        )
+
+    def select_member(
+        self, archive: zipfile.ZipFile, check: dict
+    ) -> tuple[zipfile.ZipInfo, type[DataFormat]]:
+        """Pick the one file of the archive we know how to analyse, if there is exactly one."""
+        members: list[zipfile.ZipInfo] = [
+            info for info in archive.infolist() if is_data_member(info)
+        ]
+
+        candidates: list[tuple[zipfile.ZipInfo, type[DataFormat]]] = []
+        for extensions in (DATA_EXTENSIONS, FALLBACK_EXTENSIONS):
+            candidates = [
+                (info, data_format)
+                for info in members
+                if (data_format := extensions.get(Path(info.filename).suffix.lower()))
+            ]
+            if candidates:
+                break
+
+        if not candidates:
+            raise self.io_error("No analysable file in the zip archive", check)
+        if len(candidates) > 1:
+            names = ", ".join(info.filename[:MAX_MEMBER_NAME_LENGTH] for info, _ in candidates[:5])
+            raise self.io_error(f"Several analysable files in the zip archive: {names}", check)
+
+        return candidates[0]
+
+    def extract_member(
+        self, archive: zipfile.ZipFile, member: zipfile.ZipInfo, max_size: int, check: dict
+    ) -> Path:
+        """Write a member of the archive next to it, without ever letting it grow over :max_size:"""
+        too_large = self.io_error(
+            f"Extracted file too large: {member.filename[:MAX_MEMBER_NAME_LENGTH]}", check
+        )
+        # This is what caps a decompression bomb: zipfile stops decompressing at the announced
+        # file_size (and fails the CRC check if the content does not match it), so an archive
+        # cannot deliver more bytes than it declares here.
+        if member.file_size > max_size:
+            raise too_large
+
+        destination = NamedTemporaryFile(dir=storage_path(""), delete=False)
+        try:
+            # never `archive.extract()`: the member name is attacker-controlled and could escape the
+            # download folder ("../../etc/passwd"), while a generated name cannot
+            with archive.open(member) as source:
+                written = 0
+                while chunk := source.read(EXTRACTION_CHUNK_SIZE):
+                    # belt and braces: the check above holds as long as zipfile honours file_size,
+                    # counting what we actually write holds regardless
+                    written += len(chunk)
+                    if written > max_size:
+                        raise too_large
+                    destination.write(chunk)
+        except IOException:
+            Path(destination.name).unlink(missing_ok=True)
+            raise
+        except Exception as e:
+            Path(destination.name).unlink(missing_ok=True)
+            raise self.io_error(
+                f"Could not extract {member.filename[:MAX_MEMBER_NAME_LENGTH]} from the zip archive",
+                check,
+            ) from e
+        finally:
+            destination.close()
+
+        return Path(destination.name)
+
+    def extract(self, check: dict) -> DataFormat:
+        """Extract the single analysable file of the archive, as the format able to analyse it"""
+        try:
+            archive = zipfile.ZipFile(self.path)
+        except Exception as e:
+            # BadZipFile, but also RuntimeError (encrypted archive), NotImplementedError (unsupported
+            # compression method), EOFError, OSError... none of which should take the worker down
+            raise self.io_error("Could not open the zip archive", check) from e
+
+        with archive:
+            member, data_format = self.select_member(archive, check)
+            extracted: Path = self.extract_member(
+                archive, member, data_format.max_filesize_allowed, check
+            )
+
+        return data_format(
+            file_name=extracted.name,
+            resource_id=self.resource_id,
+            dataset_id=self.dataset_id,
+        )
+
+    async def analyse(self, check: dict) -> None:
+        """Extract the archive and run the analysis of the format it holds"""
+        resource_id: str = str(check["resource_id"])
+        resource: Record | None = await Resource.update(resource_id, {"status": "EXTRACTING_ZIP"})
+
+        try:
+            file: DataFormat = self.extract(check)
+        except IOException as e:
+            check = await handle_parse_exception(e, None, check)  # type: ignore[assignment]
+            await helpers.notify_udata(resource, check)
+            await Resource.update(resource_id, {"status": None})
+            return
+        finally:
+            self.path.unlink(missing_ok=True)
+
+        log.debug(f"Extracted {file.file_name} from archive, analysing it as {type(file).__name__}")
+        await file.analyse(check=check)

--- a/udata_hydra/db/resource.py
+++ b/udata_hydra/db/resource.py
@@ -34,6 +34,8 @@ class Resource:
         "ANALYSING_WFS": "retrieving WFS service metadata",
         "TO_ANALYSE_WMS": "WMS service to be analysed",
         "ANALYSING_WMS": "retrieving WMS service metadata",
+        "TO_ANALYSE_ZIP": "zip archive to be extracted before analysing what it holds",
+        "EXTRACTING_ZIP": "currently extracting the analysable file of a zip archive",
     }
 
     @classmethod

--- a/udata_hydra/utils/errors.py
+++ b/udata_hydra/utils/errors.py
@@ -122,7 +122,8 @@ async def handle_parse_exception(
     if check:
         # e.__cause__ let us access the "inherited" error of the Exception (raise e from cause)
         # it's called explicit exception chaining and it's very cool, look it up (PEP 3134)!
-        err = f"{e.step}:{str(e.__cause__)}"
+        # exceptions raised without a chained cause carry their explanation in the message
+        err = f"{e.step}:{str(e.__cause__) if e.__cause__ else e.message}"
         if e.sentry_event_id:
             err = f"{e.step}:sentry:{e.sentry_event_id}"
         check = await Check.update(


### PR DESCRIPTION
Allow analysing [Demandes de valeurs foncières](https://www.data.gouv.fr/datasets/demandes-de-valeurs-foncieres) and [Base Sirene des entreprises et de leurs établissements (SIREN, SIRET)](https://www.data.gouv.fr/datasets/base-sirene-des-entreprises-et-de-leurs-etablissements-siren-siret). Right now they will be blocked because of size but it's better than "Ce fichier ne peut pas être prévisualisé. Téléchargez-le depuis l'onglet Téléchargements."